### PR TITLE
Added april tag code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,9 @@
     "python.autoComplete.extraPaths": [
         "/home/hexplex0xff/catkin_ws/devel/lib/python2.7/dist-packages",
         "/opt/ros/melodic/lib/python2.7/dist-packages"
+    ],
+    "python.analysis.extraPaths": [
+        "/home/hexplex0xff/catkin_ws/devel/lib/python2.7/dist-packages",
+        "/opt/ros/melodic/lib/python2.7/dist-packages"
     ]
 }

--- a/apriltag_ros/CHANGELOG.rst
+++ b/apriltag_ros/CHANGELOG.rst
@@ -1,0 +1,27 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package apriltag_ros
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+3.1.2 (2020-07-15)
+------------------
+* Add support for tagCircle21h7, tagCircle49h12 (`#69 <https://github.com/AprilRobotics/apriltag_ros/issues/69>`_)
+* Add support for tagCustom48h12 (`#65 <https://github.com/AprilRobotics/apriltag_ros/issues/65>`_)
+* Contributors: Anthony Biviano, Kyle Saltmarsh, Wolfgang Merkt, kai wu
+
+3.1.1 (2019-10-07)
+------------------
+* Add support for tagStandard41h12 and tagStandard52h13 (`#63 <https://github.com/AprilRobotics/apriltag_ros/issues/63>`_, `#59 <https://github.com/AprilRobotics/apriltag_ros/issues/59>`_).
+* Add gray image input support (`#58 <https://github.com/AprilRobotics/apriltag_ros/issues/58>`_).
+* Contributors: Alexander Reimann, Moritz Zimmermann, Samuel Bachmann, Wolfgang Merkt
+
+3.1.0 (2019-05-25)
+------------------
+* Prepare for release (3.1) and fix catkin_lint errors
+* Upgrade to AprilTag 3, fix installation, and performance improvements (`#43 <https://github.com/AprilRobotics/apriltag_ros/issues/43>`_)
+  Upgrade to AprilTag 3, fix installation, and performance improvements
+* Rename package to apriltag_ros
+  - Relates to https://github.com/AprilRobotics/apriltag_ros/issues/45
+* Contributors: Wolfgang Merkt
+
+1.0.0 (2018-05-14)
+------------------

--- a/apriltag_ros/CMakeLists.txt
+++ b/apriltag_ros/CMakeLists.txt
@@ -1,0 +1,157 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(apriltag_ros)
+
+find_package(catkin REQUIRED COMPONENTS
+  cmake_modules
+  cv_bridge
+  geometry_msgs
+  image_geometry
+  image_transport
+  message_generation
+  nodelet
+  pluginlib
+  roscpp
+  sensor_msgs
+  std_msgs
+  tf
+)
+
+find_package(Eigen3 REQUIRED)
+find_package(OpenCV REQUIRED)
+
+find_package(PkgConfig)
+pkg_search_module(apriltag REQUIRED apriltag)
+set(apriltag_INCLUDE_DIRS "${apriltag_INCLUDE_DIRS}/apriltag")
+link_directories(${apriltag_LIBDIR})
+
+# Set the build type.  Options are:
+#  Coverage       : w/ debug symbols, w/o optimization, w/ code-coverage
+#  Debug          : w/ debug symbols, w/o optimization
+#  Release        : w/o debug symbols, w/ optimization
+#  RelWithDebInfo : w/ debug symbols, w/ optimization
+#  MinSizeRel     : w/o debug symbols, w/ optimization, stripped binaries
+# We default to 'Release' if none was specified
+IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  MESSAGE(STATUS "Setting build type to 'Release' as none was specified.")
+  SET(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the build type" FORCE)
+  SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Coverage" "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+ENDIF()
+
+
+set(CMAKE_CXX_STANDARD 11)
+add_compile_options("-O3" "-funsafe-loop-optimizations" "-fsee" "-funroll-loops" "-fno-math-errno" "-funsafe-math-optimizations" "-ffinite-math-only" "-fno-signed-zeros")
+
+# Note: These options have been turned off to allow for binary releases - 
+# in local builds, they can be reactivated to achieve higher performance.
+# if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64" OR "x86_32")
+#   message("enabling msse2 for x86_64 or x86_32 architecture")
+#   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -msse2 ")
+# endif()
+# if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
+#   message("enabling -mfpu=neon -mfloat-abi=softfp for ARM architecture")
+#   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv7-a -mcpu=cortex-a9 -mfpu=neon -mtune=cortex-a9 -mvectorize-with-neon-quad -ffast-math ")
+# endif()
+
+add_message_files(
+  FILES
+  AprilTagDetection.msg
+  AprilTagDetectionArray.msg
+)
+
+add_service_files(
+  FILES
+  AnalyzeSingleImage.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+  geometry_msgs
+  sensor_msgs
+  std_msgs
+)
+
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS
+    cv_bridge
+    geometry_msgs
+    image_transport
+    message_runtime
+    nodelet
+    pluginlib
+    roscpp
+    sensor_msgs
+    std_msgs
+    tf
+  DEPENDS
+    OpenCV
+    apriltag
+  LIBRARIES
+    ${PROJECT_NAME}_common
+    ${PROJECT_NAME}_continuous_detector
+    ${PROJECT_NAME}_single_image_detector
+)
+
+###########
+## Build ##
+###########
+
+include_directories(include
+  ${catkin_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
+  ${apriltag_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME}_common src/common_functions.cpp)
+add_dependencies(${PROJECT_NAME}_common ${PROJECT_NAME}_generate_messages_cpp)
+target_link_libraries(${PROJECT_NAME}_common ${catkin_LIBRARIES} ${OpenCV_LIBRARIES} ${apriltag_LIBRARIES})
+
+add_library(${PROJECT_NAME}_continuous_detector src/continuous_detector.cpp)
+target_link_libraries(${PROJECT_NAME}_continuous_detector ${PROJECT_NAME}_common ${catkin_LIBRARIES})
+
+add_library(${PROJECT_NAME}_single_image_detector src/single_image_detector.cpp)
+target_link_libraries(${PROJECT_NAME}_single_image_detector ${PROJECT_NAME}_common ${catkin_LIBRARIES})
+
+add_executable(${PROJECT_NAME}_continuous_node src/${PROJECT_NAME}_continuous_node.cpp)
+add_dependencies(${PROJECT_NAME}_continuous_node ${PROJECT_NAME}_generate_messages_cpp)
+target_link_libraries(${PROJECT_NAME}_continuous_node ${PROJECT_NAME}_continuous_detector ${catkin_LIBRARIES})
+
+add_executable(${PROJECT_NAME}_single_image_server_node src/${PROJECT_NAME}_single_image_server_node.cpp)
+add_dependencies(${PROJECT_NAME}_single_image_server_node ${PROJECT_NAME}_generate_messages_cpp)
+target_link_libraries(${PROJECT_NAME}_single_image_server_node ${PROJECT_NAME}_single_image_detector ${catkin_LIBRARIES})
+
+add_executable(${PROJECT_NAME}_single_image_client_node src/${PROJECT_NAME}_single_image_client_node.cpp)
+add_dependencies(${PROJECT_NAME}_single_image_client_node ${PROJECT_NAME}_generate_messages_cpp)
+target_link_libraries(${PROJECT_NAME}_single_image_client_node ${PROJECT_NAME}_common ${catkin_LIBRARIES})
+
+
+#############
+## Install ##
+#############
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+)
+
+install(DIRECTORY config launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+install(FILES nodelet_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(TARGETS
+  ${PROJECT_NAME}_common
+  ${PROJECT_NAME}_continuous_detector
+  ${PROJECT_NAME}_continuous_node
+  ${PROJECT_NAME}_single_image_client_node
+  ${PROJECT_NAME}_single_image_detector
+  ${PROJECT_NAME}_single_image_server_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+)
+
+install(PROGRAMS scripts/analyze_image DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/apriltag_ros/config/settings.yaml
+++ b/apriltag_ros/config/settings.yaml
@@ -1,0 +1,12 @@
+# AprilTag 3 code parameters
+# Find descriptions in apriltag/include/apriltag.h:struct apriltag_detector
+#                      apriltag/include/apriltag.h:struct apriltag_family
+tag_family:        'tag36h11' # options: tagStandard52h13, tagStandard41h12, tag36h11, tag25h9, tag16h5, tagCustom48h12, tagCircle21h7, tagCircle49h12
+tag_threads:       2          # default: 2
+tag_decimate:      1.0        # default: 1.0
+tag_blur:          0.0        # default: 0.0
+tag_refine_edges:  1          # default: 1
+tag_debug:         0          # default: 0
+max_hamming_dist:  2          # default: 2 (Tunable parameter with 2 being a good choice - values >=3 consume large amounts of memory. Choose the largest value possible.)
+# Other parameters
+publish_tf:        true       # default: false

--- a/apriltag_ros/config/tags.yaml
+++ b/apriltag_ros/config/tags.yaml
@@ -1,0 +1,54 @@
+# # Definitions of tags to detect
+#
+# ## General remarks
+#
+# - All length in meters
+# - Ellipsis (...) signifies that the previous element can be repeated multiple times.
+#
+# ## Standalone tag definitions
+# ### Remarks
+#
+# - name is optional
+#
+# ### Syntax
+#
+# standalone_tags:
+#   [
+#     {id: ID, size: SIZE, name: NAME},
+#     ...
+#   ]
+standalone_tags:
+  [
+{id: 00, size: 0.12,frame_id: "tag_0"},
+{id: 01, size: 0.12,frame_id: "tag_1"},
+{id: 02, size: 0.12,frame_id: "tag_2"},
+{id: 03, size: 0.12,frame_id: "tag_3"},
+{id: 04, size: 0.12,frame_id: "tag_4"},
+{id: 05, size: 0.12,frame_id: "tag_5"},
+{id: 06, size: 0.12,frame_id: "tag_6"},
+{id: 07, size: 0.12,frame_id: "tag_7"}
+  ]
+# ## Tag bundle definitions
+# ### Remarks
+#
+# - name is optional
+# - x, y, z have default values of 0 thus they are optional
+# - qw has default value of 1 and qx, qy, qz have default values of 0 thus they are optional
+#
+# ### Syntax
+#
+# tag_bundles:
+#   [
+#     {
+#       name: 'CUSTOM_BUNDLE_NAME',
+#       layout:
+#         [
+#           {id: ID, size: SIZE, x: X_POS, y: Y_POS, z: Z_POS, qw: QUAT_W_VAL, qx: QUAT_X_VAL, qy: QUAT_Y_VAL, qz: QUAT_Z_VAL},
+#           ...
+#         ]
+#     },
+#     ...
+#   ]
+tag_bundles:
+  [
+  ]

--- a/apriltag_ros/include/apriltag_ros/common_functions.h
+++ b/apriltag_ros/include/apriltag_ros/common_functions.h
@@ -1,0 +1,244 @@
+/**
+ * Copyright (c) 2017, California Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of the California Institute of
+ * Technology.
+ *
+ ** common_functions.h *********************************************************
+ *
+ * Wrapper classes for AprilTag standalone and bundle detection. Main function
+ * is TagDetector::detectTags which wraps the call to core AprilTag 2
+ * algorithm, apriltag_detector_detect().
+ *
+ * $Revision: 1.0 $
+ * $Date: 2017/12/17 13:23:14 $
+ * $Author: dmalyuta $
+ *
+ * Originator:        Danylo Malyuta, JPL
+ ******************************************************************************/
+
+#ifndef APRILTAG_ROS_COMMON_FUNCTIONS_H
+#define APRILTAG_ROS_COMMON_FUNCTIONS_H
+
+#include <string>
+#include <sstream>
+#include <vector>
+#include <map>
+
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <XmlRpcException.h>
+#include <cv_bridge/cv_bridge.h>
+#include <eigen3/Eigen/Dense>
+#include <eigen3/Eigen/Geometry>
+#include <opencv2/opencv.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/core/core.hpp>
+#include <image_transport/image_transport.h>
+#include <sensor_msgs/image_encodings.h>
+#include <tf/transform_broadcaster.h>
+
+#include <apriltag.h>
+
+#include "apriltag_ros/AprilTagDetection.h"
+#include "apriltag_ros/AprilTagDetectionArray.h"
+
+namespace apriltag_ros
+{
+
+template<typename T>
+T getAprilTagOption(ros::NodeHandle& pnh,
+                    const std::string& param_name, const T & default_val)
+{
+  T param_val;
+  pnh.param<T>(param_name, param_val, default_val);
+  return param_val;
+}
+
+// Stores the properties of a tag member of a bundle
+struct TagBundleMember
+{
+  int id; // Payload ID
+  double size; // [m] Side length
+  cv::Matx44d T_oi; // Rigid transform from tag i frame to bundle origin frame
+};
+
+class StandaloneTagDescription
+{
+ public:
+  StandaloneTagDescription() {};
+  StandaloneTagDescription(int id, double size,
+                           std::string &frame_name) :
+      id_(id),
+      size_(size),
+      frame_name_(frame_name) {}
+
+  double size() { return size_; }
+  int id() { return id_; }
+  std::string& frame_name() { return frame_name_; }
+
+ private:
+  // Tag description
+  int id_;
+  double size_;
+  std::string frame_name_;
+};
+
+class TagBundleDescription
+{
+ public:
+  std::map<int, int > id2idx_; // (id2idx_[<tag ID>]=<index in tags_>) mapping
+
+  TagBundleDescription(std::string name) :
+      name_(name) {}
+
+  void addMemberTag(int id, double size, cv::Matx44d T_oi) {
+    TagBundleMember member;
+    member.id = id;
+    member.size = size;
+    member.T_oi = T_oi;
+    tags_.push_back(member);
+    id2idx_[id] = tags_.size()-1;
+  }
+
+  std::string name () const { return name_; }
+  // Get IDs of bundle member tags
+  std::vector<int> bundleIds () {
+    std::vector<int> ids;
+    for (unsigned int i = 0; i < tags_.size(); i++) {
+      ids.push_back(tags_[i].id);
+    }
+    return ids;
+  }
+  // Get sizes of bundle member tags
+  std::vector<double> bundleSizes () {
+    std::vector<double> sizes;
+    for (unsigned int i = 0; i < tags_.size(); i++) {
+      sizes.push_back(tags_[i].size);
+    }
+    return sizes;
+  }
+  int memberID (int tagID) { return tags_[id2idx_[tagID]].id; }
+  double memberSize (int tagID) { return tags_[id2idx_[tagID]].size; }
+  cv::Matx44d memberT_oi (int tagID) { return tags_[id2idx_[tagID]].T_oi; }
+
+ private:
+  // Bundle description
+  std::string name_;
+  std::vector<TagBundleMember > tags_;
+};
+
+class TagDetector
+{
+ private:
+  // Detections sorting
+  static int idComparison(const void* first, const void* second);
+
+  // Remove detections of tags with the same ID
+  void removeDuplicates();
+
+  // AprilTag 2 code's attributes
+  std::string family_;
+  int threads_;
+  double decimate_;
+  double blur_;
+  int refine_edges_;
+  int debug_;
+  int max_hamming_distance_ = 2;  // Tunable, but really, 2 is a good choice. Values of >=3
+                                  // consume prohibitively large amounts of memory, and otherwise
+                                  // you want the largest value possible.
+
+  // AprilTag 2 objects
+  apriltag_family_t *tf_;
+  apriltag_detector_t *td_;
+  zarray_t *detections_;
+
+  // Other members
+  std::map<int, StandaloneTagDescription> standalone_tag_descriptions_;
+  std::vector<TagBundleDescription > tag_bundle_descriptions_;
+  bool remove_duplicates_;
+  bool run_quietly_;
+  bool publish_tf_;
+  tf::TransformBroadcaster tf_pub_;
+  std::string camera_tf_frame_;
+
+ public:
+
+  TagDetector(ros::NodeHandle pnh);
+  ~TagDetector();
+
+  // Store standalone and bundle tag descriptions
+  std::map<int, StandaloneTagDescription> parseStandaloneTags(
+      XmlRpc::XmlRpcValue& standalone_tag_descriptions);
+  std::vector<TagBundleDescription > parseTagBundles(
+      XmlRpc::XmlRpcValue& tag_bundles);
+  double xmlRpcGetDouble(
+      XmlRpc::XmlRpcValue& xmlValue, std::string field) const;
+  double xmlRpcGetDoubleWithDefault(
+      XmlRpc::XmlRpcValue& xmlValue, std::string field,
+      double defaultValue) const;
+
+  bool findStandaloneTagDescription(
+      int id, StandaloneTagDescription*& descriptionContainer,
+      bool printWarning = true);
+
+  geometry_msgs::PoseWithCovarianceStamped makeTagPose(
+      const Eigen::Matrix4d& transform,
+      const Eigen::Quaternion<double> rot_quaternion,
+      const std_msgs::Header& header);
+
+  // Detect tags in an image
+  AprilTagDetectionArray detectTags(
+      const cv_bridge::CvImagePtr& image,
+      const sensor_msgs::CameraInfoConstPtr& camera_info);
+
+  // Get the pose of the tag in the camera frame
+  // Returns homogeneous transformation matrix [R,t;[0 0 0 1]] which
+  // takes a point expressed in the tag frame to the same point
+  // expressed in the camera frame. As usual, R is the (passive)
+  // rotation from the tag frame to the camera frame and t is the
+  // vector from the camera frame origin to the tag frame origin,
+  // expressed in the camera frame.
+  Eigen::Matrix4d getRelativeTransform(
+      std::vector<cv::Point3d > objectPoints,
+      std::vector<cv::Point2d > imagePoints,
+      double fx, double fy, double cx, double cy) const;
+  
+  void addImagePoints(apriltag_detection_t *detection,
+                      std::vector<cv::Point2d >& imagePoints) const;
+  void addObjectPoints(double s, cv::Matx44d T_oi,
+                       std::vector<cv::Point3d >& objectPoints) const;
+
+  // Draw the detected tags' outlines and payload values on the image
+  void drawDetections(cv_bridge::CvImagePtr image);
+
+  bool get_publish_tf() const { return publish_tf_; }
+};
+
+} // namespace apriltag_ros
+
+#endif // APRILTAG_ROS_COMMON_FUNCTIONS_H

--- a/apriltag_ros/include/apriltag_ros/continuous_detector.h
+++ b/apriltag_ros/include/apriltag_ros/continuous_detector.h
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2017, California Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of the California Institute of
+ * Technology.
+ *
+ ** continuous_detector.h ******************************************************
+ *
+ * Wrapper class of TagDetector class which calls TagDetector::detectTags on
+ * each newly arrived image published by a camera.
+ *
+ * $Revision: 1.0 $
+ * $Date: 2017/12/17 13:25:52 $
+ * $Author: dmalyuta $
+ *
+ * Originator:        Danylo Malyuta, JPL
+ ******************************************************************************/
+
+#ifndef APRILTAG_ROS_CONTINUOUS_DETECTOR_H
+#define APRILTAG_ROS_CONTINUOUS_DETECTOR_H
+
+#include "apriltag_ros/common_functions.h"
+
+#include <memory>
+
+#include <nodelet/nodelet.h>
+
+namespace apriltag_ros
+{
+
+class ContinuousDetector: public nodelet::Nodelet
+{
+ public:
+  ContinuousDetector() = default;
+  ~ContinuousDetector() = default;
+
+  void onInit();
+
+  void imageCallback(const sensor_msgs::ImageConstPtr& image_rect,
+                     const sensor_msgs::CameraInfoConstPtr& camera_info);
+
+ private:
+  std::shared_ptr<TagDetector> tag_detector_;
+  bool draw_tag_detections_image_;
+  cv_bridge::CvImagePtr cv_image_;
+
+  std::shared_ptr<image_transport::ImageTransport> it_;
+  image_transport::CameraSubscriber camera_image_subscriber_;
+  image_transport::Publisher tag_detections_image_publisher_;
+  ros::Publisher tag_detections_publisher_;
+};
+
+} // namespace apriltag_ros
+
+#endif // APRILTAG_ROS_CONTINUOUS_DETECTOR_H

--- a/apriltag_ros/include/apriltag_ros/single_image_detector.h
+++ b/apriltag_ros/include/apriltag_ros/single_image_detector.h
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2017, California Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of the California Institute of
+ * Technology.
+ *
+ ** single_image_detector.h ****************************************************
+ *
+ * Wrapper class of TagDetector class which calls TagDetector::detectTags on a
+ * an image stored at a specified load path and stores the output at a specified
+ * save path.
+ *
+ * $Revision: 1.0 $
+ * $Date: 2017/12/17 13:33:40 $
+ * $Author: dmalyuta $
+ *
+ * Originator:        Danylo Malyuta, JPL
+ ******************************************************************************/
+
+#ifndef APRILTAG_ROS_SINGLE_IMAGE_DETECTOR_H
+#define APRILTAG_ROS_SINGLE_IMAGE_DETECTOR_H
+
+#include "apriltag_ros/common_functions.h"
+#include <apriltag_ros/AnalyzeSingleImage.h>
+
+namespace apriltag_ros
+{
+
+class SingleImageDetector
+{
+ private:
+  TagDetector tag_detector_;
+  ros::ServiceServer single_image_analysis_service_;
+
+  ros::Publisher tag_detections_publisher_;
+  
+ public:
+  SingleImageDetector(ros::NodeHandle& nh, ros::NodeHandle& pnh);
+
+  // The function which provides the single image analysis service
+  bool analyzeImage(apriltag_ros::AnalyzeSingleImage::Request& request,
+                     apriltag_ros::AnalyzeSingleImage::Response& response);
+};
+
+} // namespace apriltag_ros
+
+#endif // APRILTAG_ROS_SINGLE_IMAGE_DETECTOR_H

--- a/apriltag_ros/launch/continuous_detection.launch
+++ b/apriltag_ros/launch/continuous_detection.launch
@@ -1,0 +1,20 @@
+<launch>
+  <arg name="launch_prefix" default="" /> <!-- set to value="gdbserver localhost:10000" for remote debugging -->
+  <arg name="node_namespace" default="apriltag_ros_continuous_node1" />
+  <arg name="camera_name" default="camera1" />
+  <arg name="camera_frame" default="camera1" />
+  <arg name="image_topic" default="image_raw" />
+
+  <!-- Set parameters -->
+  <rosparam command="load" file="$(find apriltag_ros)/config/settings.yaml" ns="$(arg node_namespace)" />
+  <rosparam command="load" file="$(find apriltag_ros)/config/tags.yaml" ns="$(arg node_namespace)" />
+  
+  <node pkg="apriltag_ros" type="apriltag_ros_continuous_node" name="$(arg node_namespace)" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" >
+    <!-- Remap topics from those used in code to those on the ROS network -->
+    <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)" />
+    <remap from="camera_info" to="$(arg camera_name)/camera_info"/>
+
+    <param name="camera_frame" type="str" value="$(arg camera_frame)" />
+    <param name="publish_tag_detections_image" type="bool" value="true" />      <!-- default: true -->
+  </node>
+</launch>

--- a/apriltag_ros/launch/continuous_detection_2.launch
+++ b/apriltag_ros/launch/continuous_detection_2.launch
@@ -1,0 +1,24 @@
+<launch>
+  <include file="$(find apriltag_ros)/launch/continuous_detection.launch" />
+  <include file="$(find apriltag_ros)/launch/continuous_detection_3.launch" />
+  <include file="$(find apriltag_ros)/launch/continuous_detection_4.launch" />
+
+  <arg name="launch_prefix" default="" /> <!-- set to value="gdbserver localhost:10000" for remote debugging -->
+  <arg name="node_namespace" default="apriltag_ros_continuous_node2" />
+  <arg name="camera_name" default="camera2" />
+  <arg name="camera_frame" default="camera2" />
+  <arg name="image_topic" default="image_raw" />
+
+  <!-- Set parameters -->
+  <rosparam command="load" file="$(find apriltag_ros)/config/settings.yaml" ns="$(arg node_namespace)" />
+  <rosparam command="load" file="$(find apriltag_ros)/config/tags.yaml" ns="$(arg node_namespace)" />
+  
+  <node pkg="apriltag_ros" type="apriltag_ros_continuous_node" name="$(arg node_namespace)" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" >
+    <!-- Remap topics from those used in code to those on the ROS network -->
+    <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)" />
+    <remap from="camera_info" to="$(arg camera_name)/camera_info"/>
+
+    <param name="camera_frame" type="str" value="$(arg camera_frame)" />
+    <param name="publish_tag_detections_image" type="bool" value="true" /> 
+  </node>
+</launch>

--- a/apriltag_ros/launch/continuous_detection_3.launch
+++ b/apriltag_ros/launch/continuous_detection_3.launch
@@ -1,0 +1,20 @@
+<launch>
+  <arg name="launch_prefix" default="" /> <!-- set to value="gdbserver localhost:10000" for remote debugging -->
+  <arg name="node_namespace" default="apriltag_ros_continuous_node3" />
+  <arg name="camera_name" default="camera3" />
+  <arg name="camera_frame" default="camera3" />
+  <arg name="image_topic" default="image_raw" />
+
+  <!-- Set parameters -->
+  <rosparam command="load" file="$(find apriltag_ros)/config/settings.yaml" ns="$(arg node_namespace)" />
+  <rosparam command="load" file="$(find apriltag_ros)/config/tags.yaml" ns="$(arg node_namespace)" />
+  
+  <node pkg="apriltag_ros" type="apriltag_ros_continuous_node" name="$(arg node_namespace)" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" >
+    <!-- Remap topics from those used in code to those on the ROS network -->
+    <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)" />
+    <remap from="camera_info" to="$(arg camera_name)/camera_info"/>
+
+    <param name="camera_frame" type="str" value="$(arg camera_frame)" />
+    <param name="publish_tag_detections_image" type="bool" value="true" />      <!-- default: true -->
+  </node>
+</launch>

--- a/apriltag_ros/launch/continuous_detection_4.launch
+++ b/apriltag_ros/launch/continuous_detection_4.launch
@@ -1,0 +1,20 @@
+<launch>
+  <arg name="launch_prefix" default="" /> <!-- set to value="gdbserver localhost:10000" for remote debugging -->
+  <arg name="node_namespace" default="apriltag_ros_continuous_node4" />
+  <arg name="camera_name" default="camera4" />
+  <arg name="camera_frame" default="camera4" />
+  <arg name="image_topic" default="image_raw" />
+
+  <!-- Set parameters -->
+  <rosparam command="load" file="$(find apriltag_ros)/config/settings.yaml" ns="$(arg node_namespace)" />
+  <rosparam command="load" file="$(find apriltag_ros)/config/tags.yaml" ns="$(arg node_namespace)" />
+  
+  <node pkg="apriltag_ros" type="apriltag_ros_continuous_node" name="$(arg node_namespace)" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" >
+    <!-- Remap topics from those used in code to those on the ROS network -->
+    <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)" />
+    <remap from="camera_info" to="$(arg camera_name)/camera_info"/>
+
+    <param name="camera_frame" type="str" value="$(arg camera_frame)" />
+    <param name="publish_tag_detections_image" type="bool" value="true" />      <!-- default: true -->
+  </node>
+</launch>

--- a/apriltag_ros/launch/continuous_detection_usbcam1.launch
+++ b/apriltag_ros/launch/continuous_detection_usbcam1.launch
@@ -1,0 +1,21 @@
+<launch>
+  <include file="$(find apriltag_ros)/launch/continuous_detection_usbcam2.launch" />
+  <arg name="launch_prefix" default="" /> <!-- set to value="gdbserver localhost:10000" for remote debugging -->
+  <arg name="node_namespace" default="apriltag_ros_continuous_node_usbcam1" />
+  <arg name="camera_name" default="usb_cam" />
+  <arg name="camera_frame" default="camera_info" />
+  <arg name="image_topic" default="image_raw" />
+
+  <!-- Set parameters -->
+  <rosparam command="load" file="$(find apriltag_ros)/config/settings.yaml" ns="$(arg node_namespace)" />
+  <rosparam command="load" file="$(find apriltag_ros)/config/tags.yaml" ns="$(arg node_namespace)" />
+  
+  <node pkg="apriltag_ros" type="apriltag_ros_continuous_node" name="$(arg node_namespace)" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" >
+    <!-- Remap topics from those used in code to those on the ROS network -->
+    <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)" />
+    <remap from="camera_info" to="$(arg camera_name)/camera_info"/>
+
+    <param name="camera_frame" type="str" value="$(arg camera_frame)" />
+    <param name="publish_tag_detections_image" type="bool" value="true" />      <!-- default: true -->
+  </node>
+</launch>

--- a/apriltag_ros/launch/continuous_detection_usbcam2.launch
+++ b/apriltag_ros/launch/continuous_detection_usbcam2.launch
@@ -1,0 +1,20 @@
+<launch>
+  <arg name="launch_prefix" default="" /> <!-- set to value="gdbserver localhost:10000" for remote debugging -->
+  <arg name="node_namespace" default="apriltag_ros_continuous_node_usbcam2" />
+  <arg name="camera_name" default="usb_cam_2" />
+  <arg name="camera_frame" default="camera_info" />
+  <arg name="image_topic" default="image_raw" />
+
+  <!-- Set parameters -->
+  <rosparam command="load" file="$(find apriltag_ros)/config/settings.yaml" ns="$(arg node_namespace)" />
+  <rosparam command="load" file="$(find apriltag_ros)/config/tags.yaml" ns="$(arg node_namespace)" />
+  
+  <node pkg="apriltag_ros" type="apriltag_ros_continuous_node" name="$(arg node_namespace)" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" >
+    <!-- Remap topics from those used in code to those on the ROS network -->
+    <remap from="image_rect" to="$(arg camera_name)/$(arg image_topic)" />
+    <remap from="camera_info" to="$(arg camera_name)/camera_info"/>
+
+    <param name="camera_frame" type="str" value="$(arg camera_frame)" />
+    <param name="publish_tag_detections_image" type="bool" value="true" />      <!-- default: true -->
+  </node>
+</launch>

--- a/apriltag_ros/launch/multi_cam.launch
+++ b/apriltag_ros/launch/multi_cam.launch
@@ -1,0 +1,12 @@
+<launch>
+    <include file="$(find apriltag_ros)/launch/continuous_detection.launch">
+        <arg name="camera_name" value="camera1"/>'
+	<arg name="node_namespace" value="apriltag_ros_continuous_node1" />
+
+    </include>
+
+    <include name="$(find apriltag_ros)/launch/continuous_detection.launch">
+        <arg name="camera_name" value="camera2"/>
+	<arg name="node_namespace" value="apriltag_ros_continuous_node2" />
+    </include>
+  </launch>

--- a/apriltag_ros/launch/single_image_client.launch
+++ b/apriltag_ros/launch/single_image_client.launch
@@ -1,0 +1,25 @@
+<launch>
+
+  <arg name="launch_prefix" default="" /> <!--set to value="gdbserver localhost:10000" for remote debugging-->
+  <arg name="node_namespace" default="apriltag_ros_single_image_client_node" />
+  <arg name="image_load_path" /> <!-- Where to load image for analysis from -->
+  <arg name="image_save_path" /> <!-- Where to save tag detections image -->
+
+  <!-- Set parameters -->
+  <rosparam command="load" file="$(find apriltag_ros)/config/settings.yaml" ns="$(arg node_namespace)" />
+  <rosparam command="load" file="$(find apriltag_ros)/config/tags.yaml" ns="$(arg node_namespace)" />
+
+  <node pkg="apriltag_ros" type="apriltag_ros_single_image_client_node" name="$(arg node_namespace)" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" >
+
+    <param name="image_load_path" type="str" value="$(arg image_load_path)" />
+    <param name="image_save_path" type="str" value="$(arg image_save_path)" />
+
+    <!-- Camera intrinsic parameters -->
+    <param name="fx" type="double" value="652.7934615847107" />
+    <param name="fy" type="double" value="653.9480389077635" />
+    <param name="cx" type="double" value="307.1288710375904" />
+    <param name="cy" type="double" value="258.7823279214385" />
+
+  </node>
+
+</launch>

--- a/apriltag_ros/launch/single_image_server.launch
+++ b/apriltag_ros/launch/single_image_server.launch
@@ -1,0 +1,12 @@
+<launch>
+
+  <arg name="launch_prefix" default="" /> <!--set to value="gdbserver localhost:10000" for remote debugging-->
+  <arg name="node_namespace" default="apriltag_ros_single_image_server_node" />
+
+  <!-- Set parameters -->
+  <rosparam command="load" file="$(find apriltag_ros)/config/settings.yaml" ns="$(arg node_namespace)" />
+  <rosparam command="load" file="$(find apriltag_ros)/config/tags.yaml" ns="$(arg node_namespace)" />
+
+  <node pkg="apriltag_ros" type="apriltag_ros_single_image_server_node" name="$(arg node_namespace)" clear_params="true" output="screen" launch-prefix="$(arg launch_prefix)" />
+
+</launch>

--- a/apriltag_ros/msg/AprilTagDetection.msg
+++ b/apriltag_ros/msg/AprilTagDetection.msg
@@ -1,0 +1,14 @@
+# Tag ID(s). If a standalone tag, this is a vector of size 1. If a tag bundle,
+# this is a vector containing the IDs of each tag in the bundle.
+int32[] id
+
+# Tag size(s). If a standalone tag, this is a vector of size 1. If a tag bundle,
+# this is a vector containing the sizes of each tag in the bundle, in the same
+# order as the IDs above.
+float64[] size
+
+# Pose in the camera frame, obtained from homography transform. If a standalone
+# tag, the homography is from the four tag corners. If a tag bundle, the
+# homography is from at least the four corners of one member tag and at most the
+# four corners of all member tags.
+geometry_msgs/PoseWithCovarianceStamped pose

--- a/apriltag_ros/msg/AprilTagDetectionArray.msg
+++ b/apriltag_ros/msg/AprilTagDetectionArray.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+AprilTagDetection[] detections

--- a/apriltag_ros/nodelet_plugins.xml
+++ b/apriltag_ros/nodelet_plugins.xml
@@ -1,0 +1,9 @@
+<library path="lib/libapriltag_ros_continuous_detector">
+    <class name="apriltag_ros/ContinuousDetector"
+        type="apriltag_ros::ContinuousDetector"
+		base_class_type="nodelet::Nodelet">
+		<description>
+          Continuous AprilTag 3 detector
+		</description>
+	</class>
+</library>

--- a/apriltag_ros/package.xml
+++ b/apriltag_ros/package.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<package>
+  <name>apriltag_ros</name>
+  <version>3.1.2</version>
+  <description>
+    A ROS wrapper of the AprilTag 3 visual fiducial detection
+    algorithm. Provides full access to the core AprilTag 3 algorithm's
+    customizations and makes the tag detection image and detected tags' poses
+    available over ROS topics (including tf). The core AprilTag 3 algorithm is
+    extended to allow the detection of tag bundles and a bundle calibration
+    script is provided (bundle detection is more accurate than single tag
+    detection). Continuous (camera image stream) and single image detector nodes
+    are available.
+  </description>
+
+  <maintainer email="danylo.malyuta@gmail.com">Danylo Malyuta</maintainer>
+  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
+
+  <author>Danylo Malyuta</author>
+
+  <license>BSD</license>
+
+  <url type="website">http://www.ros.org/wiki/apriltag_ros</url>
+  <url type="bugtracker">https://github.com/AprilRobotics/apriltag_ros/issues</url>
+  <url type="repository">https://github.com/AprilRobotics/apriltag_ros</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>apriltag</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>image_transport</build_depend>
+  <build_depend>image_geometry</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>cv_bridge</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>nodelet</build_depend>
+  <build_depend>pluginlib</build_depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>libopencv-dev</build_depend>
+  <build_depend>cmake_modules</build_depend>
+  
+  <run_depend>tf</run_depend>
+  <run_depend>apriltag</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>image_transport</run_depend>
+  <run_depend>image_geometry</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>cv_bridge</run_depend>
+  <run_depend>nodelet</run_depend>
+  <run_depend>pluginlib</run_depend>
+  <run_depend>eigen</run_depend>
+  <run_depend>libopencv-dev</run_depend>
+
+  <export>
+    <nodelet plugin="${prefix}/nodelet_plugins.xml" />
+  </export>
+</package>

--- a/apriltag_ros/scripts/analyze_image
+++ b/apriltag_ros/scripts/analyze_image
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# Detect AprilTag in a single image. Usage:
+#
+# ./analyze_image.sh <image_load_path> <image_save_path>
+#
+
+roslaunch apriltag_ros single_image_client.launch image_load_path:="$1" image_save_path:="$2"

--- a/apriltag_ros/scripts/calibrate_bundle.m
+++ b/apriltag_ros/scripts/calibrate_bundle.m
@@ -1,0 +1,341 @@
+% Copyright (c) 2017, California Institute of Technology.
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%
+% 1. Redistributions of source code must retain the above copyright notice,
+%    this list of conditions and the following disclaimer.
+% 2. Redistributions in binary form must reproduce the above copyright notice,
+%    this list of conditions and the following disclaimer in the documentation
+%    and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% The views and conclusions contained in the software and documentation are
+% those of the authors and should not be interpreted as representing official
+% policies, either expressed or implied, of the California Institute of
+% Technology.
+%
+%%% calibrate_bundle.m %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+% Script to determine AprilTag bundle relative poses to a "master" tag.
+%
+% Instructions:
+%   Record a bagfile of the /tag_detections topic where you steadily
+%   point the camera at the AprilTag bundle such that all the bundle's
+%   individual tags are visible at least once at some point (the more the
+%   better). Run the script, then copy the printed output into the tag.yaml
+%   configuration file of apriltag_ros.
+%
+% $Revision: 1.0 $
+% $Date: 2017/12/17 13:37:34 $
+% $Author: dmalyuta $
+%
+% Originator:        Danylo Malyuta, JPL
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% User inputs
+
+% Relative directory of calibration bagfile
+calibration_file = 'data/calibration.bag';
+
+% Bundle name
+bundle_name = 'my_bundle';
+
+% Master tag's ID
+master_id = 0;
+
+%% Make sure matlab_rosbag is installed
+
+if ~exist('matlab_rosbag-0.5.0-linux64','file')
+    websave('matlab_rosbag', ...
+            ['https://github.com/bcharrow/matlab_rosbag/releases/' ...
+             'download/v0.5/matlab_rosbag-0.5.0-linux64.zip']);
+    unzip('matlab_rosbag');
+    delete matlab_rosbag.zip
+end
+addpath('matlab_rosbag-0.5.0-linux64');
+
+%% Load the tag detections bagfile
+
+bag = ros.Bag.load(calibration_file);
+tag_msg = bag.readAll('/tag_detections');
+
+clear tag_data;
+N = numel(tag_msg);
+t0 = getBagTime(tag_msg{1});
+for i = 1:N
+    tag_data.t(i) = getBagTime(tag_msg{i})-t0;
+    for j = 1:numel(tag_msg{i}.detections)
+        detection = tag_msg{i}.detections(j);
+        if numel(detection.id)>1
+            % Can only use standalone tag detections for calibration!
+            % The math allows for bundles too (e.g. bundle composed of
+            % bundles) but the code does not, and it's not that useful
+            % anyway
+            warning_str = 'Skipping tag bundle detection with IDs';
+            for k = 1:numel(detection.id)
+                warning_str = sprintf('%s %d',warning_str,detection.id(k));
+            end
+            warning(warning_str);
+            continue;
+        end
+        tag_data.detection(i).id(j) = detection.id;
+        tag_data.detection(i).size(j) = detection.size;
+        % Tag position with respect to camera frame
+        tag_data.detection(i).p(:,j) = detection.pose.pose.pose.position;
+        % Tag orientation with respect to camera frame
+        % [w;x;y;z] format
+        tag_data.detection(i).q(:,j) = ...
+                         detection.pose.pose.pose.orientation([4,1,2,3]);
+    end
+end
+
+%% Compute the measured poses of each tag relative to the master tag
+
+master_size = []; % Size of the master tag
+
+% IDs, sizes, relative positions and orientations of detected tags other
+% than master
+other_ids = [];
+other_sizes = [];
+rel_p = {};
+rel_q = {};
+
+createT = @(p,q) [quat2rotmat(q) p; zeros(1,3) 1];
+invertT = @(T) [T(1:3,1:3)' -T(1:3,1:3)'*T(1:3,4); zeros(1,3) 1];
+
+N = numel(tag_data.detection);
+for i = 1:N
+    this = tag_data.detection(i);
+    
+    mi = find(this.id == master_id);
+    if isempty(mi)
+        % Master not detected in this detection, so this particular
+        % detection is useless
+        continue;
+    end
+    
+    % Get the master tag's rigid body transform to the camera frame
+    T_cm = createT(this.p(:,mi), this.q(:,mi));
+    
+    % Get the rigid body transform of every other tag to the camera frame
+    for j = 1:numel(this.id)
+        % Skip the master, but get its size first
+        if isempty(master_size)
+            master_size = this.size(j);
+        end
+        % We already have the rigid body transform from the master tag to
+        % the camera frame (T_cm)
+        if j == mi
+            continue;
+        end
+        
+        % Add ID to detected IDs, if not already there
+        id = this.id(j);
+        if ~ismember(id, other_ids)
+            other_ids(end+1) = id;
+            other_sizes(end+1) = this.size(j);
+            rel_p{end+1} = [];
+            rel_q{end+1} = [];
+        end
+        
+        % Find the index in other_ids corresponding to this tag
+        k = find(other_ids == id);
+        assert(numel(k) == 1, ...
+               'Tag ID must appear exactly once in the other_ids array');
+        
+        % Get this tag's rigid body transform to the camera frame
+        T_cj = createT(this.p(:,j), this.q(:,j));
+        
+        % Deduce this tag's rigid body transform to the master tag's frame
+        T_mj = invertT(T_cm)*T_cj;
+        
+        % Save the relative position and orientation of this tag to the
+        % master tag
+        rel_p{k}(:,end+1) = T_mj(1:3,4);
+        rel_q{k}(:,end+1) = rotmat2quat(T_mj);
+    end
+end
+
+assert(~isempty(master_size), ...
+      sprintf('Master tag with ID %d not found in detections', master_id));
+
+%% Compute (geometric) median position of each tag in master tag frame
+
+geometricMedianCost = @(x,y) sum(sqrt(sum((x-y).^2)));
+
+options = optimset('MaxIter',1000,'MaxFunEvals',1000, ...
+                   'Algorithm','interior-point', ...
+                   'TolFun', 1e-6, 'TolX', 1e-6);
+
+M = numel(rel_p);
+rel_p_median = nan(3, numel(other_ids));
+for i = 1:M
+    % Compute the mean position as the initial value for the minimization
+    % problem
+    p_0 = mean(rel_p{i},2);
+    
+    % Compute the geometric median
+    [rel_p_median(:,i),~,exitflag] = ...
+                fminsearch(@(x) geometricMedianCost(rel_p{i}, x), p_0, options);
+    assert(exitflag == 1, ...
+           sprintf(['Geometric median minimization did ' ...
+                    'not converge (exitflag %d)'], exitflag));
+end
+
+%% Compute the average orientation of each tag with respect to the master tag
+
+rel_q_mean = nan(4, numel(other_ids));
+for i = 1:M
+    % Use the method in Landis et al. "Averaging Quaternions", JGCD 2007
+    
+    % Check the sufficient uniqueness condition
+    % TODO this is a computational bottleness - without this check, script
+    % returns much faster. Any way to speed up this double-for-loop?
+    error_angle{i} = [];
+    for j = 1:size(rel_q{i},2)
+        q_1 = rel_q{i}(:,j);
+        for k = 1:size(rel_q{i},2)
+            if j==k
+                continue;
+            end
+            q_2 = rel_q{i}(:,k);
+            q_error = quatmult(quatinv(q_1),q_2);
+            % Saturate to valid acos range, which prevents imaginary output
+            % from acos due to q_error_w being infinitesimaly (to numerical
+            % precision) outside of valid [-1,1] range
+            q_error_w = min(1,max(q_error(1),-1));
+            error_angle{i}(end+1) = 2*acos(q_error_w);
+            if 2*acos(q_error_w) >= pi/2
+                warning(['Quaternion pair q_%u and q_%u for tag ID %u ' ...
+                         'are more than 90 degrees apart!'], ...
+                        j,k,other_ids(i));
+            end
+        end
+    end
+    
+    % Average quaternion method
+    Q = rel_q{i};
+    [V, D] = eig(Q*Q.');
+    [~,imax] = max(diag(D)); % Get the largest eigenvalue
+    rel_q_mean(:,i) = V(:,imax); % Corresponding eigenvector
+    if rel_q_mean(1,i) < 0
+        rel_q_mean(:,i) = -rel_q_mean(:,i); % Ensure w positive
+    end
+end
+
+%% Print output to paste in tags.yaml
+
+% Head + master tag
+fprintf([ ...
+'tag_bundles:\n' ...
+'  [\n' ...
+'    {\n' ...
+'      name: ''%s'',\n' ...
+'      layout:\n' ...
+'        [\n'], bundle_name);
+
+% All other tags detected at least once together with master tag
+for i = 0:numel(other_ids)
+    newline = ',';
+    if i == numel(other_ids)
+        newline = '';
+    end
+    if i == 0
+        fprintf('          {id: %d, size: %.2f, x: %.4f, y: %.4f, z: %.4f, qw: %.4f, qx: %.4f, qy: %.4f, qz: %.4f}%s\n', ...
+                master_id, master_size, 0, 0, 0, 1, 0, 0, 0, newline);
+    else
+        fprintf('          {id: %d, size: %.2f, x: %.4f, y: %.4f, z: %.4f, qw: %.4f, qx: %.4f, qy: %.4f, qz: %.4f}%s\n', ...
+                other_ids(i), other_sizes(i), rel_p_median(1,i), ...
+                rel_p_median(2,i), rel_p_median(3,i), rel_q_mean(1,i), ...
+                rel_q_mean(2,i), rel_q_mean(3,i), rel_q_mean(4,i), newline);
+    end
+end
+
+% Tail
+fprintf([ ...
+'        ]\n'...
+'    }\n'...
+'  ]\n']);
+
+%% Local functions
+
+function t = getBagTime(bagfile)
+    t = double(bagfile.header.stamp.sec)+ ...
+        double(bagfile.header.stamp.nsec)/1e9;
+end
+
+function R = quat2rotmat(q)
+    % Creates an ACTIVE rotation matrix from a quaternion
+    w = q(1);
+    x = q(2);
+    y = q(3);
+    z = q(4);
+
+    R = [1-2*(y^2+z^2)  2*(x*y-w*z)    2*(x*z+w*y)
+         2*(x*y+w*z)    1-2*(x^2+z^2)  2*(y*z-w*x)
+         2*(x*z-w*y)    2*(y*z+w*x)    1-2*(x^2+y^2)];
+end
+
+function q = rotmat2quat(R)
+    % Adapted for MATLAB from
+    % http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/
+    tr = R(1,1) + R(2,2) + R(3,3);
+
+    if tr > 0
+      S = sqrt(tr+1.0) * 2; % S=4*qw 
+      qw = 0.25 * S;
+      qx = (R(3,2) - R(2,3)) / S;
+      qy = (R(1,3) - R(3,1)) / S; 
+      qz = (R(2,1) - R(1,2)) / S; 
+    elseif (R(1,1) > R(2,2)) && (R(1,1) > R(3,3)) 
+      S = sqrt(1.0 + R(1,1) - R(2,2) - R(3,3)) * 2; % S=4*qx 
+      qw = (R(3,2) - R(2,3)) / S;
+      qx = 0.25 * S;
+      qy = (R(1,2) + R(2,1)) / S; 
+      qz = (R(1,3) + R(3,1)) / S; 
+    elseif (R(2,2) > R(3,3))
+      S = sqrt(1.0 + R(2,2) - R(1,1) - R(3,3)) * 2; % S=4*qy
+      qw = (R(1,3) - R(3,1)) / S;
+      qx = (R(1,2) + R(2,1)) / S; 
+      qy = 0.25 * S;
+      qz = (R(2,3) + R(3,2)) / S; 
+    else
+      S = sqrt(1.0 + R(3,3) - R(1,1) - R(2,2)) * 2; % S=4*qz
+      qw = (R(2,1) - R(1,2)) / S;
+      qx = (R(1,3) + R(3,1)) / S;
+      qy = (R(2,3) + R(3,2)) / S;
+      qz = 0.25 * S;
+    end
+
+    q = [qw qx qy qz]';
+end
+
+function c = quatmult(a,b)
+    % More humanly understandable version:
+    % Omegaa = [a((1)) -a((2):(4)).'
+    %           a((2):(4)) a((1))*eye((3))-[0 -a((4)) a((3)); a((4)) 0 -a((2));-a((3)) a((2)) 0]];
+    % c = Omegaa*b;
+    % More optimized version:
+    c_w = a(1)*b(1) - a(2)*b(2) - a(3)*b(3) - a(4)*b(4);
+    c_x = a(1)*b(2) + a(2)*b(1) - a(3)*b(4) + a(4)*b(3);
+    c_y = a(1)*b(3) + a(3)*b(1) + a(2)*b(4) - a(4)*b(2);
+    c_z = a(1)*b(4) - a(2)*b(3) + a(3)*b(2) + a(4)*b(1);
+    c = [c_w; c_x; c_y; c_z];
+end
+
+function qinv = quatinv(q)
+    qinv = [q(1); -q(2:4)];
+end

--- a/apriltag_ros/src/apriltag_ros_continuous_node.cpp
+++ b/apriltag_ros/src/apriltag_ros_continuous_node.cpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2017, California Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of the California Institute of
+ * Technology.
+ */
+
+#include <ros/ros.h>
+
+#include <nodelet/loader.h>
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "apriltag_ros");
+
+  nodelet::Loader nodelet;
+  nodelet::M_string remap(ros::names::getRemappings());
+  nodelet::V_string nargv;
+
+  nodelet.load(ros::this_node::getName(),
+              "apriltag_ros/ContinuousDetector",
+              remap, nargv);
+
+  ros::spin();
+  return 0;
+}

--- a/apriltag_ros/src/apriltag_ros_single_image_client_node.cpp
+++ b/apriltag_ros/src/apriltag_ros_single_image_client_node.cpp
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) 2017, California Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of the California Institute of
+ * Technology.
+ */
+
+#include "apriltag_ros/common_functions.h"
+#include <apriltag_ros/AnalyzeSingleImage.h>
+
+bool getRosParameter (ros::NodeHandle& pnh, std::string name, double& param)
+{
+  // Write parameter "name" from ROS Parameter Server into param
+  // Return true if successful, false otherwise
+  if (pnh.hasParam(name.c_str()))
+  {
+    pnh.getParam(name.c_str(), param);
+    ROS_INFO_STREAM("Set camera " << name.c_str() << " = " << param);
+    return true;
+  }
+  else
+  {
+    ROS_ERROR_STREAM("Could not find " << name.c_str() << " parameter!");
+    return false;
+  }
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "apriltag_ros_single_image_client");
+
+  ros::NodeHandle nh;
+  ros::NodeHandle pnh("~");
+
+  ros::ServiceClient client =
+      nh.serviceClient<apriltag_ros::AnalyzeSingleImage>(
+          "single_image_tag_detection");
+
+  // Get the request parameters
+  apriltag_ros::AnalyzeSingleImage service;
+  service.request.full_path_where_to_get_image =
+      apriltag_ros::getAprilTagOption<std::string>(
+          pnh, "image_load_path", "");
+  if (service.request.full_path_where_to_get_image.empty())
+  {
+    return 1;
+  }
+  service.request.full_path_where_to_save_image =
+      apriltag_ros::getAprilTagOption<std::string>(
+          pnh, "image_save_path", "");
+  if (service.request.full_path_where_to_save_image.empty())
+  {
+    return 1;
+  }
+
+  // Replicate sensors_msgs/CameraInfo message (must be up-to-date with the
+  // analyzed image!)  
+  service.request.camera_info.distortion_model = "plumb_bob";
+  double fx, fy, cx, cy;
+  if (!getRosParameter(pnh, "fx", fx))
+    return 1;
+  if (!getRosParameter(pnh, "fy", fy))
+    return 1;
+  if (!getRosParameter(pnh, "cx", cx))
+    return 1;
+  if (!getRosParameter(pnh, "cy", cy))
+    return 1;
+  // Intrinsic camera matrix for the raw (distorted) images
+  service.request.camera_info.K[0] = fx;
+  service.request.camera_info.K[2] = cx;
+  service.request.camera_info.K[4] = fy;
+  service.request.camera_info.K[5] = cy;
+  service.request.camera_info.K[8] = 1.0;
+
+  // Call the service (detect tags in the image specified by the
+  // image_load_path)
+  if (client.call(service))
+  {
+    // use parameter run_quielty=false in order to have the service
+    // print out the tag position and orientation
+    if (service.response.tag_detections.detections.size() == 0)
+    {
+      ROS_WARN_STREAM("No detected tags!");
+    }
+  }
+  else
+  {
+    ROS_ERROR("Failed to call service single_image_tag_detection");
+    return 1;
+  }
+
+  return 0; // happy ending
+}

--- a/apriltag_ros/src/apriltag_ros_single_image_server_node.cpp
+++ b/apriltag_ros/src/apriltag_ros_single_image_server_node.cpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2017, California Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of the California Institute of
+ * Technology.
+ */
+
+#include "apriltag_ros/common_functions.h"
+#include "apriltag_ros/single_image_detector.h"
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "apriltag_ros_single_image_server");
+
+  ros::NodeHandle nh;
+  ros::NodeHandle pnh("~");
+
+  apriltag_ros::SingleImageDetector continuous_tag_detector(nh, pnh);
+  
+  ros::spin();
+}

--- a/apriltag_ros/src/common_functions.cpp
+++ b/apriltag_ros/src/common_functions.cpp
@@ -1,0 +1,798 @@
+/**
+ * Copyright (c) 2017, California Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of the California Institute of
+ * Technology.
+ */
+
+#include "apriltag_ros/common_functions.h"
+#include "image_geometry/pinhole_camera_model.h"
+
+#include "common/homography.h"
+#include "tagStandard52h13.h"
+#include "tagStandard41h12.h"
+#include "tag36h11.h"
+#include "tag25h9.h"
+#include "tag16h5.h"
+#include "tagCustom48h12.h"
+#include "tagCircle21h7.h"
+#include "tagCircle49h12.h"
+
+namespace apriltag_ros
+{
+
+TagDetector::TagDetector(ros::NodeHandle pnh) :
+    family_(getAprilTagOption<std::string>(pnh, "tag_family", "tag36h11")),
+    threads_(getAprilTagOption<int>(pnh, "tag_threads", 4)),
+    decimate_(getAprilTagOption<double>(pnh, "tag_decimate", 1.0)),
+    blur_(getAprilTagOption<double>(pnh, "tag_blur", 0.0)),
+    refine_edges_(getAprilTagOption<int>(pnh, "tag_refine_edges", 1)),
+    debug_(getAprilTagOption<int>(pnh, "tag_debug", 0)),
+    max_hamming_distance_(getAprilTagOption<int>(pnh, "max_hamming_dist", 2)),
+    publish_tf_(getAprilTagOption<bool>(pnh, "publish_tf", false))
+{
+  // Parse standalone tag descriptions specified by user (stored on ROS
+  // parameter server)
+  XmlRpc::XmlRpcValue standalone_tag_descriptions;
+  if(!pnh.getParam("standalone_tags", standalone_tag_descriptions))
+  {
+    ROS_WARN("No april tags specified");
+  }
+  else
+  {
+    try
+    {
+      standalone_tag_descriptions_ =
+          parseStandaloneTags(standalone_tag_descriptions);
+    }
+    catch(XmlRpc::XmlRpcException e)
+    {
+      // in case any of the asserts in parseStandaloneTags() fail
+      ROS_ERROR_STREAM("Error loading standalone tag descriptions: " <<
+                       e.getMessage().c_str());
+    }
+  }
+
+  // parse tag bundle descriptions specified by user (stored on ROS parameter
+  // server)
+  XmlRpc::XmlRpcValue tag_bundle_descriptions;
+  if(!pnh.getParam("tag_bundles", tag_bundle_descriptions))
+  {
+    ROS_WARN("No tag bundles specified");
+  }
+  else
+  {
+    try
+    {
+      tag_bundle_descriptions_ = parseTagBundles(tag_bundle_descriptions);
+    }
+    catch(XmlRpc::XmlRpcException e)
+    {
+      // In case any of the asserts in parseStandaloneTags() fail
+      ROS_ERROR_STREAM("Error loading tag bundle descriptions: " <<
+                       e.getMessage().c_str());
+    }
+  }
+
+  // Optionally remove duplicate detections in scene. Defaults to removing
+  if(!pnh.getParam("remove_duplicates", remove_duplicates_))
+  {
+    ROS_WARN("remove_duplicates parameter not provided. Defaulting to true");
+    remove_duplicates_ = true;
+  }
+
+  // Define the tag family whose tags should be searched for in the camera
+  // images
+  if (family_ == "tagStandard52h13")
+  {
+    tf_ = tagStandard52h13_create();
+  }
+  else if (family_ == "tagStandard41h12")
+  {
+    tf_ = tagStandard41h12_create();
+  }
+  else if (family_ == "tag36h11")
+  {
+    tf_ = tag36h11_create();
+  }
+  else if (family_ == "tag25h9")
+  {
+    tf_ = tag25h9_create();
+  }
+  else if (family_ == "tag16h5")
+  {
+    tf_ = tag16h5_create();
+  }
+  else if (family_ == "tagCustom48h12")
+  {
+    tf_ = tagCustom48h12_create();
+  }
+  else if (family_ == "tagCircle21h7")
+  {
+    tf_ = tagCircle21h7_create();
+  }
+  else if (family_ == "tagCircle49h12")
+  {
+    tf_ = tagCircle49h12_create();
+  }
+  else
+  {
+    ROS_WARN("Invalid tag family specified! Aborting");
+    exit(1);
+  }
+
+  // Create the AprilTag 2 detector
+  td_ = apriltag_detector_create();
+  apriltag_detector_add_family_bits(td_, tf_, max_hamming_distance_);
+  td_->quad_decimate = (float)decimate_;
+  td_->quad_sigma = (float)blur_;
+  td_->nthreads = threads_;
+  td_->debug = debug_;
+  td_->refine_edges = refine_edges_;
+
+  detections_ = NULL;
+
+  // Get tf frame name to use for the camera
+  if (!pnh.getParam("camera_frame", camera_tf_frame_))
+  {
+    ROS_WARN_STREAM("Camera frame not specified, using 'camera'");
+    camera_tf_frame_ = "camera";
+  }
+}
+
+// destructor
+TagDetector::~TagDetector() {
+  // free memory associated with tag detector
+  apriltag_detector_destroy(td_);
+
+  // Free memory associated with the array of tag detections
+  apriltag_detections_destroy(detections_);
+
+  // free memory associated with tag family
+  if (family_ == "tagStandard52h13")
+  {
+    tagStandard52h13_destroy(tf_);
+  }
+  else if (family_ == "tagStandard41h12")
+  {
+    tagStandard41h12_destroy(tf_);
+  }
+  else if (family_ == "tag36h11")
+  {
+    tag36h11_destroy(tf_);
+  }
+  else if (family_ == "tag25h9")
+  {
+    tag25h9_destroy(tf_);
+  }
+  else if (family_ == "tag16h5")
+  {
+    tag16h5_destroy(tf_);
+  }
+  else if (family_ == "tagCustom48h12")
+  {
+    tagCustom48h12_destroy(tf_);
+  }
+  else if (family_ == "tagCircle21h7")
+  {
+    tagCircle21h7_destroy(tf_);
+  }
+  else if (family_ == "tagCircle49h12")
+  {
+    tagCircle49h12_destroy(tf_);
+  }
+}
+
+AprilTagDetectionArray TagDetector::detectTags (
+    const cv_bridge::CvImagePtr& image,
+    const sensor_msgs::CameraInfoConstPtr& camera_info) {
+  // Convert image to AprilTag code's format
+  cv::Mat gray_image;
+  if (image->image.channels() == 1)
+  {
+    gray_image = image->image;
+  }
+  else
+  {
+    cv::cvtColor(image->image, gray_image, CV_BGR2GRAY);
+  }
+  image_u8_t apriltag_image = { .width = gray_image.cols,
+                                  .height = gray_image.rows,
+                                  .stride = gray_image.cols,
+                                  .buf = gray_image.data
+  };
+
+  image_geometry::PinholeCameraModel camera_model;
+  camera_model.fromCameraInfo(camera_info);
+
+  // Get camera intrinsic properties for rectified image.
+  double fx = camera_model.fx(); // focal length in camera x-direction [px]
+  double fy = camera_model.fy(); // focal length in camera y-direction [px]
+  double cx = camera_model.cx(); // optical center x-coordinate [px]
+  double cy = camera_model.cy(); // optical center y-coordinate [px]
+
+  // Run AprilTag 2 algorithm on the image
+  if (detections_)
+  {
+    apriltag_detections_destroy(detections_);
+    detections_ = NULL;
+  }
+  detections_ = apriltag_detector_detect(td_, &apriltag_image);
+
+  // If remove_dulpicates_ is set to true, then duplicate tags are not allowed.
+  // Thus any duplicate tag IDs visible in the scene must include at least 1
+  // erroneous detection. Remove any tags with duplicate IDs to ensure removal
+  // of these erroneous detections
+  if (remove_duplicates_)
+  {
+    removeDuplicates();
+  }
+
+  // Compute the estimated translation and rotation individually for each
+  // detected tag
+  AprilTagDetectionArray tag_detection_array;
+  std::vector<std::string > detection_names;
+  tag_detection_array.header = image->header;
+  std::map<std::string, std::vector<cv::Point3d > > bundleObjectPoints;
+  std::map<std::string, std::vector<cv::Point2d > > bundleImagePoints;
+  for (int i=0; i < zarray_size(detections_); i++)
+  {
+    // Get the i-th detected tag
+    apriltag_detection_t *detection;
+    zarray_get(detections_, i, &detection);
+
+    // Bootstrap this for loop to find this tag's description amongst
+    // the tag bundles. If found, add its points to the bundle's set of
+    // object-image corresponding points (tag corners) for cv::solvePnP.
+    // Don't yet run cv::solvePnP on the bundles, though, since we're still in
+    // the process of collecting all the object-image corresponding points
+    int tagID = detection->id;
+    bool is_part_of_bundle = false;
+    for (unsigned int j=0; j<tag_bundle_descriptions_.size(); j++)
+    {
+      // Iterate over the registered bundles
+      TagBundleDescription bundle = tag_bundle_descriptions_[j];
+
+      if (bundle.id2idx_.find(tagID) != bundle.id2idx_.end())
+      {
+        // This detected tag belongs to the j-th tag bundle (its ID was found in
+        // the bundle description)
+        is_part_of_bundle = true;
+        std::string bundleName = bundle.name();
+
+        //===== Corner points in the world frame coordinates
+        double s = bundle.memberSize(tagID)/2;
+        addObjectPoints(s, bundle.memberT_oi(tagID),
+                        bundleObjectPoints[bundleName]);
+
+        //===== Corner points in the image frame coordinates
+        addImagePoints(detection, bundleImagePoints[bundleName]);
+      }
+    }
+
+    // Find this tag's description amongst the standalone tags
+    // Print warning when a tag was found that is neither part of a
+    // bundle nor standalone (thus it is a tag in the environment
+    // which the user specified no description for, or Apriltags
+    // misdetected a tag (bad ID or a false positive)).
+    StandaloneTagDescription* standaloneDescription;
+    if (!findStandaloneTagDescription(tagID, standaloneDescription,
+                                      !is_part_of_bundle))
+    {
+      continue;
+    }
+
+    //=================================================================
+    // The remainder of this for loop is concerned with standalone tag
+    // poses!
+    double tag_size = standaloneDescription->size();
+
+    // Get estimated tag pose in the camera frame.
+    //
+    // Note on frames:
+    // The raw AprilTag 2 uses the following frames:
+    //   - camera frame: looking from behind the camera (like a
+    //     photographer), x is right, y is up and z is towards you
+    //     (i.e. the back of camera)
+    //   - tag frame: looking straight at the tag (oriented correctly),
+    //     x is right, y is down and z is away from you (into the tag).
+    // But we want:
+    //   - camera frame: looking from behind the camera (like a
+    //     photographer), x is right, y is down and z is straight
+    //     ahead
+    //   - tag frame: looking straight at the tag (oriented correctly),
+    //     x is right, y is up and z is towards you (out of the tag).
+    // Using these frames together with cv::solvePnP directly avoids
+    // AprilTag 2's frames altogether.
+    // TODO solvePnP[Ransac] better?
+    std::vector<cv::Point3d > standaloneTagObjectPoints;
+    std::vector<cv::Point2d > standaloneTagImagePoints;
+    addObjectPoints(tag_size/2, cv::Matx44d::eye(), standaloneTagObjectPoints);
+    addImagePoints(detection, standaloneTagImagePoints);
+    Eigen::Matrix4d transform = getRelativeTransform(standaloneTagObjectPoints,
+                                                     standaloneTagImagePoints,
+                                                     fx, fy, cx, cy);
+    Eigen::Matrix3d rot = transform.block(0, 0, 3, 3);
+    Eigen::Quaternion<double> rot_quaternion(rot);
+
+    geometry_msgs::PoseWithCovarianceStamped tag_pose =
+        makeTagPose(transform, rot_quaternion, image->header);
+
+    // Add the detection to the back of the tag detection array
+    AprilTagDetection tag_detection;
+    tag_detection.pose = tag_pose;
+    tag_detection.id.push_back(detection->id);
+    tag_detection.size.push_back(tag_size);
+    tag_detection_array.detections.push_back(tag_detection);
+    detection_names.push_back(standaloneDescription->frame_name());
+  }
+
+  //=================================================================
+  // Estimate bundle origin pose for each bundle in which at least one
+  // member tag was detected
+
+  for (unsigned int j=0; j<tag_bundle_descriptions_.size(); j++)
+  {
+    // Get bundle name
+    std::string bundleName = tag_bundle_descriptions_[j].name();
+
+    std::map<std::string,
+             std::vector<cv::Point3d> >::iterator it =
+        bundleObjectPoints.find(bundleName);
+    if (it != bundleObjectPoints.end())
+    {
+      // Some member tags of this bundle were detected, get the bundle's
+      // position!
+      TagBundleDescription& bundle = tag_bundle_descriptions_[j];
+
+      Eigen::Matrix4d transform =
+          getRelativeTransform(bundleObjectPoints[bundleName],
+                               bundleImagePoints[bundleName], fx, fy, cx, cy);
+      Eigen::Matrix3d rot = transform.block(0, 0, 3, 3);
+      Eigen::Quaternion<double> rot_quaternion(rot);
+
+      geometry_msgs::PoseWithCovarianceStamped bundle_pose =
+          makeTagPose(transform, rot_quaternion, image->header);
+
+      // Add the detection to the back of the tag detection array
+      AprilTagDetection tag_detection;
+      tag_detection.pose = bundle_pose;
+      tag_detection.id = bundle.bundleIds();
+      tag_detection.size = bundle.bundleSizes();
+      tag_detection_array.detections.push_back(tag_detection);
+      detection_names.push_back(bundle.name());
+    }
+  }
+
+  // If set, publish the transform /tf topic
+  if (publish_tf_) {
+    for (unsigned int i=0; i<tag_detection_array.detections.size(); i++) {
+      geometry_msgs::PoseStamped pose;
+      pose.pose = tag_detection_array.detections[i].pose.pose.pose;
+      pose.header = tag_detection_array.detections[i].pose.header;
+      tf::Stamped<tf::Transform> tag_transform;
+      tf::poseStampedMsgToTF(pose, tag_transform);
+      tf_pub_.sendTransform(tf::StampedTransform(tag_transform,
+                                                 tag_transform.stamp_,
+                                                 camera_tf_frame_,
+                                                 detection_names[i]));
+    }
+  }
+
+  return tag_detection_array;
+}
+
+int TagDetector::idComparison (const void* first, const void* second)
+{
+  int id1 = ((apriltag_detection_t*) first)->id;
+  int id2 = ((apriltag_detection_t*) second)->id;
+  return (id1 < id2) ? -1 : ((id1 == id2) ? 0 : 1);
+}
+
+void TagDetector::removeDuplicates ()
+{
+  zarray_sort(detections_, &idComparison);
+  int count = 0;
+  bool duplicate_detected = false;
+  while (true)
+  {
+    if (count > zarray_size(detections_)-1)
+    {
+      // The entire detection set was parsed
+      return;
+    }
+    apriltag_detection_t *detection;
+    zarray_get(detections_, count, &detection);
+    int id_current = detection->id;
+    // Default id_next value of -1 ensures that if the last detection
+    // is a duplicated tag ID, it will get removed
+    int id_next = -1;
+    if (count < zarray_size(detections_)-1)
+    {
+      zarray_get(detections_, count+1, &detection);
+      id_next = detection->id;
+    }
+    if (id_current == id_next || (id_current != id_next && duplicate_detected))
+    {
+      duplicate_detected = true;
+      // Remove the current tag detection from detections array
+      int shuffle = 0;
+      zarray_remove_index(detections_, count, shuffle);
+      if (id_current != id_next)
+      {
+        ROS_WARN_STREAM("Pruning tag ID " << id_current << " because it "
+                        "appears more than once in the image.");
+        duplicate_detected = false; // Reset
+      }
+      continue;
+    }
+    else
+    {
+      count++;
+    }
+  }
+}
+
+void TagDetector::addObjectPoints (
+    double s, cv::Matx44d T_oi, std::vector<cv::Point3d >& objectPoints) const
+{
+  // Add to object point vector the tag corner coordinates in the bundle frame
+  // Going counterclockwise starting from the bottom left corner
+  objectPoints.push_back(T_oi.get_minor<3, 4>(0, 0)*cv::Vec4d(-s,-s, 0, 1));
+  objectPoints.push_back(T_oi.get_minor<3, 4>(0, 0)*cv::Vec4d( s,-s, 0, 1));
+  objectPoints.push_back(T_oi.get_minor<3, 4>(0, 0)*cv::Vec4d( s, s, 0, 1));
+  objectPoints.push_back(T_oi.get_minor<3, 4>(0, 0)*cv::Vec4d(-s, s, 0, 1));
+}
+
+void TagDetector::addImagePoints (
+    apriltag_detection_t *detection,
+    std::vector<cv::Point2d >& imagePoints) const
+{
+  // Add to image point vector the tag corners in the image frame
+  // Going counterclockwise starting from the bottom left corner
+  double tag_x[4] = {-1,1,1,-1};
+  double tag_y[4] = {1,1,-1,-1}; // Negated because AprilTag tag local
+                                 // frame has y-axis pointing DOWN
+                                 // while we use the tag local frame
+                                 // with y-axis pointing UP
+  for (int i=0; i<4; i++)
+  {
+    // Homography projection taking tag local frame coordinates to image pixels
+    double im_x, im_y;
+    homography_project(detection->H, tag_x[i], tag_y[i], &im_x, &im_y);
+    imagePoints.push_back(cv::Point2d(im_x, im_y));
+  }
+}
+
+Eigen::Matrix4d TagDetector::getRelativeTransform(
+    std::vector<cv::Point3d > objectPoints,
+    std::vector<cv::Point2d > imagePoints,
+    double fx, double fy, double cx, double cy) const
+{
+  // perform Perspective-n-Point camera pose estimation using the
+  // above 3D-2D point correspondences
+  cv::Mat rvec, tvec;
+  cv::Matx33d cameraMatrix(fx,  0, cx,
+                           0,  fy, cy,
+                           0,   0,  1);
+  cv::Vec4f distCoeffs(0,0,0,0); // distortion coefficients
+  // TODO Perhaps something like SOLVEPNP_EPNP would be faster? Would
+  // need to first check WHAT is a bottleneck in this code, and only
+  // do this if PnP solution is the bottleneck.
+  cv::solvePnP(objectPoints, imagePoints, cameraMatrix, distCoeffs, rvec, tvec);
+  cv::Matx33d R;
+  cv::Rodrigues(rvec, R);
+  Eigen::Matrix3d wRo;
+  wRo << R(0,0), R(0,1), R(0,2), R(1,0), R(1,1), R(1,2), R(2,0), R(2,1), R(2,2);
+
+  Eigen::Matrix4d T; // homogeneous transformation matrix
+  T.topLeftCorner(3, 3) = wRo;
+  T.col(3).head(3) <<
+      tvec.at<double>(0), tvec.at<double>(1), tvec.at<double>(2);
+  T.row(3) << 0,0,0,1;
+  return T;
+}
+
+geometry_msgs::PoseWithCovarianceStamped TagDetector::makeTagPose(
+    const Eigen::Matrix4d& transform,
+    const Eigen::Quaternion<double> rot_quaternion,
+    const std_msgs::Header& header)
+{
+  geometry_msgs::PoseWithCovarianceStamped pose;
+  pose.header = header;
+  //===== Position and orientation
+  pose.pose.pose.position.x    = transform(0, 3);
+  pose.pose.pose.position.y    = transform(1, 3);
+  pose.pose.pose.position.z    = transform(2, 3);
+  pose.pose.pose.orientation.x = rot_quaternion.x();
+  pose.pose.pose.orientation.y = rot_quaternion.y();
+  pose.pose.pose.orientation.z = rot_quaternion.z();
+  pose.pose.pose.orientation.w = rot_quaternion.w();
+  return pose;
+}
+
+void TagDetector::drawDetections (cv_bridge::CvImagePtr image)
+{
+  for (int i = 0; i < zarray_size(detections_); i++)
+  {
+    apriltag_detection_t *det;
+    zarray_get(detections_, i, &det);
+
+    // Check if this ID is present in config/tags.yaml
+    // Check if is part of a tag bundle
+    int tagID = det->id;
+    bool is_part_of_bundle = false;
+    for (unsigned int j=0; j<tag_bundle_descriptions_.size(); j++)
+    {
+      TagBundleDescription bundle = tag_bundle_descriptions_[j];
+      if (bundle.id2idx_.find(tagID) != bundle.id2idx_.end())
+      {
+        is_part_of_bundle = true;
+        break;
+      }
+    }
+    // If not part of a bundle, check if defined as a standalone tag
+    StandaloneTagDescription* standaloneDescription;
+    if (!is_part_of_bundle &&
+        !findStandaloneTagDescription(tagID, standaloneDescription, false))
+    {
+      // Neither a standalone tag nor part of a bundle, so this is a "rogue"
+      // tag, skip it.
+      continue;
+    }
+
+    // Draw tag outline with edge colors green, blue, blue, red
+    // (going counter-clockwise, starting from lower-left corner in
+    // tag coords). cv::Scalar(Blue, Green, Red) format for the edge
+    // colors!
+    line(image->image, cv::Point((int)det->p[0][0], (int)det->p[0][1]),
+         cv::Point((int)det->p[1][0], (int)det->p[1][1]),
+         cv::Scalar(0, 0xff, 0)); // green
+    line(image->image, cv::Point((int)det->p[0][0], (int)det->p[0][1]),
+         cv::Point((int)det->p[3][0], (int)det->p[3][1]),
+         cv::Scalar(0, 0, 0xff)); // red
+    line(image->image, cv::Point((int)det->p[1][0], (int)det->p[1][1]),
+         cv::Point((int)det->p[2][0], (int)det->p[2][1]),
+         cv::Scalar(0xff, 0, 0)); // blue
+    line(image->image, cv::Point((int)det->p[2][0], (int)det->p[2][1]),
+         cv::Point((int)det->p[3][0], (int)det->p[3][1]),
+         cv::Scalar(0xff, 0, 0)); // blue
+
+    // Print tag ID in the middle of the tag
+    std::stringstream ss;
+    ss << det->id;
+    cv::String text = ss.str();
+    int fontface = cv::FONT_HERSHEY_SCRIPT_SIMPLEX;
+    double fontscale = 0.5;
+    int baseline;
+    cv::Size textsize = cv::getTextSize(text, fontface,
+                                        fontscale, 2, &baseline);
+    cv::putText(image->image, text,
+                cv::Point((int)(det->c[0]-textsize.width/2),
+                          (int)(det->c[1]+textsize.height/2)),
+                fontface, fontscale, cv::Scalar(0xff, 0x99, 0), 2);
+  }
+}
+
+// Parse standalone tag descriptions
+std::map<int, StandaloneTagDescription> TagDetector::parseStandaloneTags (
+    XmlRpc::XmlRpcValue& standalone_tags)
+{
+  // Create map that will be filled by the function and returned in the end
+  std::map<int, StandaloneTagDescription> descriptions;
+  // Ensure the type is correct
+  ROS_ASSERT(standalone_tags.getType() == XmlRpc::XmlRpcValue::TypeArray);
+  // Loop through all tag descriptions
+  for (int32_t i = 0; i < standalone_tags.size(); i++)
+  {
+
+    // i-th tag description
+    XmlRpc::XmlRpcValue& tag_description = standalone_tags[i];
+
+    // Assert the tag description is a struct
+    ROS_ASSERT(tag_description.getType() ==
+               XmlRpc::XmlRpcValue::TypeStruct);
+    // Assert type of field "id" is an int
+    ROS_ASSERT(tag_description["id"].getType() ==
+               XmlRpc::XmlRpcValue::TypeInt);
+    // Assert type of field "size" is a double
+    ROS_ASSERT(tag_description["size"].getType() ==
+               XmlRpc::XmlRpcValue::TypeDouble);
+
+    int id = (int)tag_description["id"]; // tag id
+    // Tag size (square, side length in meters)
+    double size = (double)tag_description["size"];
+
+    // Custom frame name, if such a field exists for this tag
+    std::string frame_name;
+    if(tag_description.hasMember("name"))
+    {
+      // Assert type of field "name" is a string
+      ROS_ASSERT(tag_description["name"].getType() ==
+                 XmlRpc::XmlRpcValue::TypeString);
+      frame_name = (std::string)tag_description["name"];
+    }
+    else
+    {
+      std::stringstream frame_name_stream;
+      frame_name_stream << "tag_" << id;
+      frame_name = frame_name_stream.str();
+    }
+
+    StandaloneTagDescription description(id, size, frame_name);
+    ROS_INFO_STREAM("Loaded tag config: " << id << ", size: " <<
+                    size << ", frame_name: " << frame_name.c_str());
+    // Add this tag's description to map of descriptions
+    descriptions.insert(std::make_pair(id, description));
+  }
+
+  return descriptions;
+}
+
+// parse tag bundle descriptions
+std::vector<TagBundleDescription > TagDetector::parseTagBundles (
+    XmlRpc::XmlRpcValue& tag_bundles)
+{
+  std::vector<TagBundleDescription > descriptions;
+  ROS_ASSERT(tag_bundles.getType() == XmlRpc::XmlRpcValue::TypeArray);
+
+  // Loop through all tag bundle descritions
+  for (int32_t i=0; i<tag_bundles.size(); i++)
+  {
+    ROS_ASSERT(tag_bundles[i].getType() == XmlRpc::XmlRpcValue::TypeStruct);
+    // i-th tag bundle description
+    XmlRpc::XmlRpcValue& bundle_description = tag_bundles[i];
+
+    std::string bundleName;
+    if (bundle_description.hasMember("name"))
+    {
+      ROS_ASSERT(bundle_description["name"].getType() ==
+                 XmlRpc::XmlRpcValue::TypeString);
+      bundleName = (std::string)bundle_description["name"];
+    }
+    else
+    {
+      std::stringstream bundle_name_stream;
+      bundle_name_stream << "bundle_" << i;
+      bundleName = bundle_name_stream.str();
+    }
+    TagBundleDescription bundle_i(bundleName);
+    ROS_INFO("Loading tag bundle '%s'",bundle_i.name().c_str());
+
+    ROS_ASSERT(bundle_description["layout"].getType() ==
+               XmlRpc::XmlRpcValue::TypeArray);
+    XmlRpc::XmlRpcValue& member_tags = bundle_description["layout"];
+
+    // Loop through each member tag of the bundle
+    for (int32_t j=0; j<member_tags.size(); j++)
+    {
+      ROS_ASSERT(member_tags[j].getType() == XmlRpc::XmlRpcValue::TypeStruct);
+      XmlRpc::XmlRpcValue& tag = member_tags[j];
+
+      ROS_ASSERT(tag["id"].getType() == XmlRpc::XmlRpcValue::TypeInt);
+      int id = tag["id"];
+
+      ROS_ASSERT(tag["size"].getType() == XmlRpc::XmlRpcValue::TypeDouble);
+      double size = tag["size"];
+
+      // Make sure that if this tag was specified also as standalone,
+      // then the sizes match
+      StandaloneTagDescription* standaloneDescription;
+      if (findStandaloneTagDescription(id, standaloneDescription, false))
+      {
+        ROS_ASSERT(size == standaloneDescription->size());
+      }
+
+      // Get this tag's pose with respect to the bundle origin
+      double x  = xmlRpcGetDoubleWithDefault(tag, "x", 0.);
+      double y  = xmlRpcGetDoubleWithDefault(tag, "y", 0.);
+      double z  = xmlRpcGetDoubleWithDefault(tag, "z", 0.);
+      double qw = xmlRpcGetDoubleWithDefault(tag, "qw", 1.);
+      double qx = xmlRpcGetDoubleWithDefault(tag, "qx", 0.);
+      double qy = xmlRpcGetDoubleWithDefault(tag, "qy", 0.);
+      double qz = xmlRpcGetDoubleWithDefault(tag, "qz", 0.);
+      Eigen::Quaterniond q_tag(qw, qx, qy, qz);
+      q_tag.normalize();
+      Eigen::Matrix3d R_oi = q_tag.toRotationMatrix();
+
+      // Build the rigid transform from tag_j to the bundle origin
+      cv::Matx44d T_mj(R_oi(0,0), R_oi(0,1), R_oi(0,2), x,
+                       R_oi(1,0), R_oi(1,1), R_oi(1,2), y,
+                       R_oi(2,0), R_oi(2,1), R_oi(2,2), z,
+                       0,         0,         0,         1);
+
+      // Register the tag member
+      bundle_i.addMemberTag(id, size, T_mj);
+      ROS_INFO_STREAM(" " << j << ") id: " << id << ", size: " << size << ", "
+                          << "p = [" << x << "," << y << "," << z << "], "
+                          << "q = [" << qw << "," << qx << "," << qy << ","
+                          << qz << "]");
+    }
+    descriptions.push_back(bundle_i);
+  }
+  return descriptions;
+}
+
+double TagDetector::xmlRpcGetDouble (XmlRpc::XmlRpcValue& xmlValue,
+                                     std::string field) const
+{
+  ROS_ASSERT((xmlValue[field].getType() == XmlRpc::XmlRpcValue::TypeDouble) ||
+             (xmlValue[field].getType() == XmlRpc::XmlRpcValue::TypeInt));
+  if (xmlValue[field].getType() == XmlRpc::XmlRpcValue::TypeInt)
+  {
+    int tmp = xmlValue[field];
+    return (double)tmp;
+  }
+  else
+  {
+    return xmlValue[field];
+  }
+}
+
+double TagDetector::xmlRpcGetDoubleWithDefault (XmlRpc::XmlRpcValue& xmlValue,
+                                                std::string field,
+                                                double defaultValue) const
+{
+  if (xmlValue.hasMember(field))
+  {
+    ROS_ASSERT((xmlValue[field].getType() == XmlRpc::XmlRpcValue::TypeDouble) ||
+        (xmlValue[field].getType() == XmlRpc::XmlRpcValue::TypeInt));
+    if (xmlValue[field].getType() == XmlRpc::XmlRpcValue::TypeInt)
+    {
+      int tmp = xmlValue[field];
+      return (double)tmp;
+    }
+    else
+    {
+      return xmlValue[field];
+    }
+  }
+  else
+  {
+    return defaultValue;
+  }
+}
+
+bool TagDetector::findStandaloneTagDescription (
+    int id, StandaloneTagDescription*& descriptionContainer, bool printWarning)
+{
+  std::map<int, StandaloneTagDescription>::iterator description_itr =
+      standalone_tag_descriptions_.find(id);
+  if (description_itr == standalone_tag_descriptions_.end())
+  {
+    if (printWarning)
+    {
+      ROS_WARN_THROTTLE(10.0, "Requested description of standalone tag ID [%d],"
+                        " but no description was found...",id);
+    }
+    return false;
+  }
+  descriptionContainer = &(description_itr->second);
+  return true;
+}
+
+} // namespace apriltag_ros

--- a/apriltag_ros/src/continuous_detector.cpp
+++ b/apriltag_ros/src/continuous_detector.cpp
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2017, California Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of the California Institute of
+ * Technology.
+ */
+
+#include "apriltag_ros/continuous_detector.h"
+
+#include <pluginlib/class_list_macros.h>
+
+PLUGINLIB_EXPORT_CLASS(apriltag_ros::ContinuousDetector, nodelet::Nodelet);
+
+namespace apriltag_ros
+{
+void ContinuousDetector::onInit ()
+{
+  ros::NodeHandle& nh = getNodeHandle();
+  ros::NodeHandle& pnh = getPrivateNodeHandle();
+
+  tag_detector_ = std::shared_ptr<TagDetector>(new TagDetector(pnh));
+  draw_tag_detections_image_ = getAprilTagOption<bool>(pnh, 
+      "publish_tag_detections_image", false);
+  it_ = std::shared_ptr<image_transport::ImageTransport>(
+      new image_transport::ImageTransport(nh));
+
+  camera_image_subscriber_ =
+      it_->subscribeCamera("image_rect", 1,
+                          &ContinuousDetector::imageCallback, this);
+  tag_detections_publisher_ =
+      nh.advertise<AprilTagDetectionArray>("tag_detections", 1);
+  if (draw_tag_detections_image_)
+  {
+    tag_detections_image_publisher_ = it_->advertise("tag_detections_image", 1);
+  }
+}
+
+void ContinuousDetector::imageCallback (
+    const sensor_msgs::ImageConstPtr& image_rect,
+    const sensor_msgs::CameraInfoConstPtr& camera_info)
+{
+  // Lazy updates:
+  // When there are no subscribers _and_ when tf is not published,
+  // skip detection.
+  if (tag_detections_publisher_.getNumSubscribers() == 0 &&
+      tag_detections_image_publisher_.getNumSubscribers() == 0 &&
+      !tag_detector_->get_publish_tf())
+  {
+    // ROS_INFO_STREAM("No subscribers and no tf publishing, skip processing.");
+    return;
+  }
+
+  // Convert ROS's sensor_msgs::Image to cv_bridge::CvImagePtr in order to run
+  // AprilTag 2 on the iamge
+  try
+  {
+    cv_image_ = cv_bridge::toCvCopy(image_rect, image_rect->encoding);
+  }
+  catch (cv_bridge::Exception& e)
+  {
+    ROS_ERROR("cv_bridge exception: %s", e.what());
+    return;
+  }
+
+  // Publish detected tags in the image by AprilTag 2
+  tag_detections_publisher_.publish(
+      tag_detector_->detectTags(cv_image_,camera_info));
+
+  // Publish the camera image overlaid by outlines of the detected tags and
+  // their payload values
+  if (draw_tag_detections_image_)
+  {
+    tag_detector_->drawDetections(cv_image_);
+    tag_detections_image_publisher_.publish(cv_image_->toImageMsg());
+  }
+}
+
+} // namespace apriltag_ros

--- a/apriltag_ros/src/single_image_detector.cpp
+++ b/apriltag_ros/src/single_image_detector.cpp
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2017, California Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation are
+ * those of the authors and should not be interpreted as representing official
+ * policies, either expressed or implied, of the California Institute of
+ * Technology.
+ */
+
+#include "apriltag_ros/single_image_detector.h"
+
+#include <opencv2/highgui/highgui.hpp>
+#include <std_msgs/Header.h>
+
+namespace apriltag_ros
+{
+
+SingleImageDetector::SingleImageDetector (ros::NodeHandle& nh,
+                                          ros::NodeHandle& pnh) :
+    tag_detector_(pnh)
+{
+  // Advertise the single image analysis service
+  single_image_analysis_service_ =
+      nh.advertiseService("single_image_tag_detection",
+                          &SingleImageDetector::analyzeImage, this);
+  tag_detections_publisher_ =
+      nh.advertise<AprilTagDetectionArray>("tag_detections", 1);
+  ROS_INFO_STREAM("Ready to do tag detection on single images");
+}
+
+bool SingleImageDetector::analyzeImage(
+    apriltag_ros::AnalyzeSingleImage::Request& request,
+    apriltag_ros::AnalyzeSingleImage::Response& response)
+{
+
+  ROS_INFO("[ Summoned to analyze image ]");
+  ROS_INFO("Image load path: %s",
+           request.full_path_where_to_get_image.c_str());
+  ROS_INFO("Image save path: %s",
+           request.full_path_where_to_save_image.c_str());
+
+  // Read the image
+  cv::Mat image = cv::imread(request.full_path_where_to_get_image,
+                             cv::IMREAD_COLOR);
+  if (image.data == NULL)
+  {
+    // Cannot read image
+    ROS_ERROR_STREAM("Could not read image " <<
+                     request.full_path_where_to_get_image.c_str());
+    return false;
+  }
+
+  // Detect tags in the image
+  cv_bridge::CvImagePtr loaded_image(new cv_bridge::CvImage(std_msgs::Header(),
+                                                            "bgr8", image));
+  loaded_image->header.frame_id = "camera";
+  response.tag_detections =
+      tag_detector_.detectTags(loaded_image,sensor_msgs::CameraInfoConstPtr(
+          new sensor_msgs::CameraInfo(request.camera_info)));
+
+  // Publish detected tags (AprilTagDetectionArray, basically an array of
+  // geometry_msgs/PoseWithCovarianceStamped)
+  tag_detections_publisher_.publish(response.tag_detections);
+
+  // Save tag detections image
+  tag_detector_.drawDetections(loaded_image);
+  cv::imwrite(request.full_path_where_to_save_image, loaded_image->image);
+
+  ROS_INFO("Done!\n");
+
+  return true;
+}
+
+} // namespace apriltag_ros

--- a/apriltag_ros/srv/AnalyzeSingleImage.srv
+++ b/apriltag_ros/srv/AnalyzeSingleImage.srv
@@ -1,0 +1,14 @@
+# Service which takes in:
+#
+#   full_path_to_image : full path to a .jpg image
+#
+# and returns:
+#
+#                 pose : the pose of the tag in the camera frame
+#  tag_detection_image : an image with the detected tag's border highlighted and payload value printed
+
+string full_path_where_to_get_image
+string full_path_where_to_save_image
+sensor_msgs/CameraInfo camera_info
+---
+apriltag_ros/AprilTagDetectionArray tag_detections

--- a/dot_control/scripts/tf_apriltag.py
+++ b/dot_control/scripts/tf_apriltag.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import rospy
+from visualization_msgs.msg import Marker, MarkerArray
+from apriltag_ros.msg import AprilTagDetectionArray
+from geometry_msgs.msg import PoseStamped
+import tf
+
+global marker_arry, visited_ids
+marker_arry = MarkerArray()
+visited_ids = {}
+
+N_TAGS = 8
+
+def tags_callback(msg):
+    detections = msg.detections  
+
+    print("Found ", len(detections), " tags!!")
+
+    for detection in detections:
+        if detection.id in visited_ids:
+            continue
+        
+        visited_ids[detection.id] = True
+        pose = detection.pose
+
+        pose_stamped = PoseStamped()
+        pose_stamped.header = detection.pose.header
+        pose_stamped.pose = pose.pose.pose
+
+        try:
+            tranformed_pose_stamped = listener.transformPose('/world', pose_stamped)
+
+        except (tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException) as e:
+            print(e)
+            continue
+
+        marker_msg = Marker()
+        marker_msg.header = tranformed_pose_stamped.header
+        marker_msg.id = detection.id
+        marker_msg.pose = tranformed_pose_stamped.pose
+
+        marker_arry.markers.append(marker_msg)
+
+        print("Found tag ", detection.id, ' at (', 
+        tranformed_pose_stamped.pose.position.x, ', ', 
+        tranformed_pose_stamped.pose.position.y)
+    
+    if len(visited_ids) == N_TAGS:
+        marker_arry_pub.publish(marker_arry)
+
+if __name__ == '__main__':
+    try:
+        rospy.init_node('tf_apriltag')
+        listener = tf.TransformListener()
+
+        marker_arry_pub = rospy.Publisher('/tags_marker_array', MarkerArray, queue_size=10)
+        rospy.Subscriber("/tag_detections", AprilTagDetectionArray, tags_callback)
+        rospy.spin()
+
+    except rospy.ROSInterruptException:
+        rospy.loginfo("Interrupted.")

--- a/dot_gazebo/launch/gazebo.launch
+++ b/dot_gazebo/launch/gazebo.launch
@@ -15,12 +15,16 @@
     </include>
     <param name="robot_description" command="$(find xacro)/xacro 
                                                         '$(find dot_description)/xacro/main.urdf.xacro'" />
-
-    <arg name="x" default="1"/>
-    <arg name="y" default="1"/>
+    <param name="camera_description" command="cat '$(find dot_gazebo)/urdf/cameras.urdf'" />
+    <arg name="x" default="0"/>
+    <arg name="y" default="0"/>
     <arg name="z" default="0.5"/>
 
     <node name="mybot_spawn" pkg="gazebo_ros" type="spawn_model" output="screen"
           args="-urdf -param robot_description -model dot -x $(arg x) -y $(arg y) -z $(arg z)" />
+
+    <node name="cameras_spawn" pkg="gazebo_ros" type="spawn_model" output="screen"
+          args="-urdf -param camera_description -model cameras -x 0.0 -y 0.0 -z 0.0" />
+    
   <include file="$(find dot_control)/launch/bring_up.launch" /> 
 </launch>

--- a/dot_gazebo/urdf/cameras.urdf
+++ b/dot_gazebo/urdf/cameras.urdf
@@ -1,0 +1,312 @@
+<?xml version="1.0" ?>
+
+<robot name="bot" xmlns:xacro="https://www.ros.org/wiki/xacro" >
+
+<gazebo>
+    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+    <robotNamespace>/bot</robotNamespace>
+    </plugin>
+</gazebo>  
+
+<link name="world" /> 
+
+<gazebo reference="camera1">
+  <sensor type="camera" name="camera1">
+    <update_rate>30.0</update_rate>
+    <camera name="head">
+      <horizontal_fov>1.3962634</horizontal_fov>
+      <image>
+        <width>800</width>
+        <height>800</height>
+        <format>R8G8B8</format>
+      </image>
+      <clip>
+        <near>0.02</near>
+        <far>300</far>
+      </clip>
+      <noise>
+        <type>gaussian</type>
+        <!-- Noise is sampled independently per pixel on each frame.
+             That pixel's noise value is added to each of its color
+             channels, which at that point lie in the range [0,1]. -->
+        <mean>0.0</mean>
+        <stddev>0.007</stddev>
+      </noise>
+    </camera>
+    <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+      <alwaysOn>true</alwaysOn>
+      <updateRate>0.0</updateRate>
+      <cameraName>camera1</cameraName>
+      <imageTopicName>image_raw</imageTopicName>
+      <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+      <frameName>camera1</frameName>
+      <hackBaseline>0.07</hackBaseline>
+      <distortionK1>0.0</distortionK1>
+      <distortionK2>0.0</distortionK2>
+      <distortionK3>0.0</distortionK3>
+      <distortionT1>0.0</distortionT1>
+      <distortionT2>0.0</distortionT2>
+    </plugin>
+  </sensor>
+</gazebo>
+
+
+
+  <joint name="camera_joint1" type="fixed">
+    <axis xyz="0 1 0" />
+    <origin xyz="-0.25 0 1" rpy="0 1.571 0"/>
+    <parent link="world"/>
+    <child link="camera1"/>
+  </joint>
+
+  <!-- Camera1 -->
+  <link name="camera1">
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+    <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </collision>
+
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+    <box size="0.1 0.1 0.1"/>
+      </geometry>
+    </visual>
+
+    <inertial>
+      <mass value="1e-5" />
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertia ixx="1e-6" ixy="0" ixz="0" iyy="1e-6" iyz="0" izz="1e-6" />
+    </inertial>
+  </link>
+
+
+
+
+
+
+  <gazebo reference="camera2">
+    <sensor type="camera" name="camera2">
+      <update_rate>30.0</update_rate>
+      <camera name="head">
+        <horizontal_fov>1.3962634</horizontal_fov>
+        <image>
+          <width>800</width>
+          <height>800</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+        <noise>
+          <type>gaussian</type>
+          <!-- Noise is sampled independently per pixel on each frame.
+               That pixel's noise value is added to each of its color
+               channels, which at that point lie in the range [0,1]. -->
+          <mean>0.0</mean>
+          <stddev>0.007</stddev>
+        </noise>
+      </camera>
+      <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+        <alwaysOn>true</alwaysOn>
+        <updateRate>0.0</updateRate>
+        <cameraName>camera2</cameraName>
+        <imageTopicName>image_raw</imageTopicName>
+        <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+        <frameName>camera2</frameName>
+        <hackBaseline>0.07</hackBaseline>
+        <distortionK1>0.0</distortionK1>
+        <distortionK2>0.0</distortionK2>
+        <distortionK3>0.0</distortionK3>
+        <distortionT1>0.0</distortionT1>
+        <distortionT2>0.0</distortionT2>
+      </plugin>
+    </sensor>
+  </gazebo>
+
+  
+    <joint name="camera_joint2" type="fixed">
+      <axis xyz="0 1 0" />
+      <origin xyz="0.25 0 1" rpy="0 1.571 0"/>
+      <parent link="world"/>
+      <child link="camera2"/>
+    </joint>
+  
+    <!-- Camera 2-->
+    <link name="camera2">
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+      <box size="0.1 0.1 0.1"/>
+        </geometry>
+      </collision>
+  
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <geometry>
+      <box size="0.1 0.1 0.1"/>
+        </geometry>
+      </visual>
+  
+      <inertial>
+        <mass value="1e-5" />
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <inertia ixx="1e-6" ixy="0" ixz="0" iyy="1e-6" iyz="0" izz="1e-6" />
+      </inertial>
+    </link>
+
+
+
+
+    <gazebo reference="camera3">
+      <sensor type="camera" name="camera3">
+        <update_rate>30.0</update_rate>
+        <camera name="head">
+          <horizontal_fov>1.3962634</horizontal_fov>
+          <image>
+            <width>800</width>
+            <height>800</height>
+            <format>R8G8B8</format>
+          </image>
+          <clip>
+            <near>0.02</near>
+            <far>300</far>
+          </clip>
+          <noise>
+            <type>gaussian</type>
+            <!-- Noise is sampled independently per pixel on each frame.
+                 That pixel's noise value is added to each of its color
+                 channels, which at that point lie in the range [0,1]. -->
+            <mean>0.0</mean>
+            <stddev>0.007</stddev>
+          </noise>
+        </camera>
+        <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+          <alwaysOn>true</alwaysOn>
+          <updateRate>0.0</updateRate>
+          <cameraName>camera3</cameraName>
+          <imageTopicName>image_raw</imageTopicName>
+          <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+          <frameName>camera3</frameName>
+          <hackBaseline>0.07</hackBaseline>
+          <distortionK1>0.0</distortionK1>
+          <distortionK2>0.0</distortionK2>
+          <distortionK3>0.0</distortionK3>
+          <distortionT1>0.0</distortionT1>
+          <distortionT2>0.0</distortionT2>
+        </plugin>
+      </sensor>
+    </gazebo>
+  
+    
+      <joint name="camera_joint3" type="fixed">
+        <axis xyz="0 1 0" />
+        <origin xyz="0.75 0 1" rpy="0 1.571 0"/>
+        <parent link="world"/>
+        <child link="camera3"/>
+      </joint>
+    
+      <!-- Camera 3-->
+      <link name="camera3">
+        <collision>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+        <box size="0.1 0.1 0.1"/>
+          </geometry>
+        </collision>
+    
+        <visual>
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <geometry>
+        <box size="0.1 0.1 0.1"/>
+          </geometry>
+        </visual>
+    
+        <inertial>
+          <mass value="1e-5" />
+          <origin xyz="0 0 0" rpy="0 0 0"/>
+          <inertia ixx="1e-6" ixy="0" ixz="0" iyy="1e-6" iyz="0" izz="1e-6" />
+        </inertial>
+      </link>
+
+
+
+
+
+
+
+      <gazebo reference="camera4">
+        <sensor type="camera" name="camera4">
+          <update_rate>30.0</update_rate>
+          <camera name="head">
+            <horizontal_fov>1.3962634</horizontal_fov>
+            <image>
+              <width>800</width>
+              <height>800</height>
+              <format>R8G8B8</format>
+            </image>
+            <clip>
+              <near>0.02</near>
+              <far>300</far>
+            </clip>
+            <noise>
+              <type>gaussian</type>
+              <!-- Noise is sampled independently per pixel on each frame.
+                   That pixel's noise value is added to each of its color
+                   channels, which at that point lie in the range [0,1]. -->
+              <mean>0.0</mean>
+              <stddev>0.007</stddev>
+            </noise>
+          </camera>
+          <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+            <alwaysOn>true</alwaysOn>
+            <updateRate>0.0</updateRate>
+            <cameraName>camera4</cameraName>
+            <imageTopicName>image_raw</imageTopicName>
+            <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+            <frameName>camera4</frameName>
+            <hackBaseline>0.07</hackBaseline>
+            <distortionK1>0.0</distortionK1>
+            <distortionK2>0.0</distortionK2>
+            <distortionK3>0.0</distortionK3>
+            <distortionT1>0.0</distortionT1>
+            <distortionT2>0.0</distortionT2>
+          </plugin>
+        </sensor>
+      </gazebo>
+    
+      
+        <joint name="camera_joint4" type="fixed">
+          <axis xyz="0 1 0" />
+          <origin xyz="-0.75 0 1" rpy="0 1.571 0"/>
+          <parent link="world"/>
+          <child link="camera4"/>
+        </joint>
+      
+        <!-- Camera 4-->
+        <link name="camera4">
+          <collision>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <geometry>
+          <box size="0.1 0.1 0.1"/>
+            </geometry>
+          </collision>
+      
+          <visual>
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <geometry>
+          <box size="0.1 0.1 0.1"/>
+            </geometry>
+          </visual>
+      
+          <inertial>
+            <mass value="1e-5" />
+            <origin xyz="0 0 0" rpy="0 0 0"/>
+            <inertia ixx="1e-6" ixy="0" ixz="0" iyy="1e-6" iyz="0" izz="1e-6" />
+          </inertial>
+        </link>
+
+</robot>


### PR DESCRIPTION
Includes camera spawning in `gazebo.launch` and `dot_control/scripts/tf_apriltag.py` file which collects pose information of all april tags and transforms all positions from their respective frames to `/world` frame.